### PR TITLE
Fixed minor error with deleting a field. If json is undefined then gi…

### DIFF
--- a/admin/src/swaggerRestServer.js
+++ b/admin/src/swaggerRestServer.js
@@ -163,7 +163,7 @@ const convertHTTPResponseToREST = ({ response, type, resource, params }) => {
         case CREATE:
             return { data: { ...params.data, id: json.id } };
         default:
-            return { data: json };
+            return { data: json ? json : {} };
     }
 };
 


### PR DESCRIPTION
Deleting a record was raising an error that the `data` key did not exist in the response. Fixed by checking if `json` in the response is undefined (therefore data is made to not exist) and if so it is replaced with an empty object so data is defined. Delete then works as expected and returns to the list view with the deleted field not present.