### PR TITLE
Generated code and updated SwaggerRestServer to handle no limit perPa…

### DIFF
--- a/admin/src/resources/AdminNote.js
+++ b/admin/src/resources/AdminNote.js
@@ -69,10 +69,10 @@ export const AdminNoteList = props => (
 export const AdminNoteCreate = props => (
     <Create {...props} title="AdminNote Create">
         <SimpleForm validate={validationCreateAdminNote}>
-            <ReferenceInput label="User" source="user_id" reference="users" allowEmpty>
+            <ReferenceInput label="User" source="user_id" reference="users" perPage={0} allowEmpty>
                 <SelectInput optionText="username" />
             </ReferenceInput>
-            <ReferenceInput label="User" source="creator_id" reference="users" allowEmpty>
+            <ReferenceInput label="User" source="creator_id" reference="users" perPage={0} allowEmpty>
                 <DisabledInput optionText="username" />
             </ReferenceInput>
             <TextInput source="note" />

--- a/admin/src/resources/Domain.js
+++ b/admin/src/resources/Domain.js
@@ -61,7 +61,7 @@ export const DomainList = props => (
 export const DomainCreate = props => (
     <Create {...props} title="Domain Create">
         <SimpleForm validate={validationCreateDomain}>
-            <ReferenceInput label="Parent" source="parent_id" reference="domains" allowEmpty>
+            <ReferenceInput label="Parent" source="parent_id" reference="domains" perPage={0} allowEmpty>
                 <SelectInput optionText="name" />
             </ReferenceInput>
             <TextInput source="name" />
@@ -105,7 +105,7 @@ export const DomainShow = props => (
 export const DomainEdit = props => (
     <Edit {...props} title="Domain Edit">
         <SimpleForm validate={validationEditDomain}>
-            <ReferenceInput label="Parent" source="parent_id" reference="domains" allowEmpty>
+            <ReferenceInput label="Parent" source="parent_id" reference="domains" perPage={0} allowEmpty>
                 <SelectInput optionText="name" />
             </ReferenceInput>
             <TextInput source="name" />

--- a/admin/src/resources/DomainRole.js
+++ b/admin/src/resources/DomainRole.js
@@ -64,10 +64,10 @@ export const DomainRoleList = props => (
 export const DomainRoleCreate = props => (
     <Create {...props} title="DomainRole Create">
         <SimpleForm validate={validationCreateDomainRole}>
-            <ReferenceInput label="Domain" source="domain_id" reference="domains" allowEmpty>
+            <ReferenceInput label="Domain" source="domain_id" reference="domains" perPage={0} allowEmpty>
                 <SelectInput optionText="name" />
             </ReferenceInput>
-            <ReferenceInput label="Role" source="role_id" reference="roles" allowEmpty>
+            <ReferenceInput label="Role" source="role_id" reference="roles" perPage={0} allowEmpty>
                 <SelectInput optionText="label" />
             </ReferenceInput>
             <BooleanInput source="grant_implicitly" />

--- a/admin/src/resources/Invitation.js
+++ b/admin/src/resources/Invitation.js
@@ -73,7 +73,7 @@ export const InvitationList = props => (
 export const InvitationCreate = props => (
     <Create {...props} title="Invitation Create">
         <SimpleForm validate={validationCreateInvitation}>
-            <ReferenceInput label="User" source="invitor_id" reference="users" allowEmpty>
+            <ReferenceInput label="User" source="invitor_id" reference="users" perPage={0} allowEmpty>
                 <SelectInput optionText="username" />
             </ReferenceInput>
             <TextInput source="first_name" />

--- a/admin/src/resources/InvitationDomainRole.js
+++ b/admin/src/resources/InvitationDomainRole.js
@@ -60,13 +60,13 @@ export const InvitationDomainRoleList = props => (
 export const InvitationDomainRoleCreate = props => (
     <Create {...props} title="InvitationDomainRole Create">
         <SimpleForm validate={validationCreateInvitationDomainRole}>
-            <ReferenceInput label="Invitation" source="invitation_id" reference="invitations" allowEmpty>
+            <ReferenceInput label="Invitation" source="invitation_id" reference="invitations" perPage={0} allowEmpty>
                 <SelectInput optionText="email" />
             </ReferenceInput>
-            <ReferenceInput label="Domain" source="domain_id" reference="domains" allowEmpty>
+            <ReferenceInput label="Domain" source="domain_id" reference="domains" perPage={0} allowEmpty>
                 <SelectInput optionText="name" />
             </ReferenceInput>
-            <ReferenceInput label="Role" source="role_id" reference="roles" allowEmpty>
+            <ReferenceInput label="Role" source="role_id" reference="roles" perPage={0} allowEmpty>
                 <SelectInput optionText="label" />
             </ReferenceInput>
         </SimpleForm>

--- a/admin/src/resources/InvitationSiteRole.js
+++ b/admin/src/resources/InvitationSiteRole.js
@@ -60,13 +60,13 @@ export const InvitationSiteRoleList = props => (
 export const InvitationSiteRoleCreate = props => (
     <Create {...props} title="InvitationSiteRole Create">
         <SimpleForm validate={validationCreateInvitationSiteRole}>
-            <ReferenceInput label="Invitation" source="invitation_id" reference="invitations" allowEmpty>
+            <ReferenceInput label="Invitation" source="invitation_id" reference="invitations" perPage={0} allowEmpty>
                 <SelectInput optionText="email" />
             </ReferenceInput>
-            <ReferenceInput label="Site" source="site_id" reference="sites" allowEmpty>
+            <ReferenceInput label="Site" source="site_id" reference="sites" perPage={0} allowEmpty>
                 <SelectInput optionText="name" />
             </ReferenceInput>
-            <ReferenceInput label="Role" source="role_id" reference="roles" allowEmpty>
+            <ReferenceInput label="Role" source="role_id" reference="roles" perPage={0} allowEmpty>
                 <SelectInput optionText="label" />
             </ReferenceInput>
         </SimpleForm>

--- a/admin/src/resources/RoleResourcePermission.js
+++ b/admin/src/resources/RoleResourcePermission.js
@@ -59,13 +59,13 @@ export const RoleResourcePermissionList = props => (
 export const RoleResourcePermissionCreate = props => (
     <Create {...props} title="RoleResourcePermission Create">
         <SimpleForm validate={validationCreateRoleResourcePermission}>
-            <ReferenceInput label="Role" source="role_id" reference="roles" allowEmpty>
+            <ReferenceInput label="Role" source="role_id" reference="roles" perPage={0} allowEmpty>
                 <SelectInput optionText="label" />
             </ReferenceInput>
-            <ReferenceInput label="Resource" source="resource_id" reference="resources" allowEmpty>
+            <ReferenceInput label="Resource" source="resource_id" reference="resources" perPage={0} allowEmpty>
                 <SelectInput optionText="urn" />
             </ReferenceInput>
-            <ReferenceInput label="Permission" source="permission_id" reference="permissions" allowEmpty>
+            <ReferenceInput label="Permission" source="permission_id" reference="permissions" perPage={0} allowEmpty>
                 <SelectInput optionText="name" />
             </ReferenceInput>
         </SimpleForm>

--- a/admin/src/resources/Site.js
+++ b/admin/src/resources/Site.js
@@ -70,10 +70,10 @@ export const SiteList = props => (
 export const SiteCreate = props => (
     <Create {...props} title="Site Create">
         <SimpleForm validate={validationCreateSite}>
-            <ReferenceInput label="Client" source="client_id" reference="clients" allowEmpty>
+            <ReferenceInput label="Client" source="client_id" reference="clients" perPage={0} allowEmpty>
                 <SelectInput optionText="name" />
             </ReferenceInput>
-            <ReferenceInput label="Domain" source="domain_id" reference="domains" allowEmpty>
+            <ReferenceInput label="Domain" source="domain_id" reference="domains" perPage={0} allowEmpty>
                 <SelectInput optionText="name" />
             </ReferenceInput>
             <TextInput source="name" />
@@ -114,10 +114,10 @@ export const SiteShow = props => (
 export const SiteEdit = props => (
     <Edit {...props} title="Site Edit">
         <SimpleForm validate={validationEditSite}>
-            <ReferenceInput label="Client" source="client_id" reference="clients" allowEmpty>
+            <ReferenceInput label="Client" source="client_id" reference="clients" perPage={0} allowEmpty>
                 <SelectInput optionText="name" />
             </ReferenceInput>
-            <ReferenceInput label="Domain" source="domain_id" reference="domains" allowEmpty>
+            <ReferenceInput label="Domain" source="domain_id" reference="domains" perPage={0} allowEmpty>
                 <SelectInput optionText="name" />
             </ReferenceInput>
             <TextInput source="name" />

--- a/admin/src/resources/SiteDataSchema.js
+++ b/admin/src/resources/SiteDataSchema.js
@@ -60,7 +60,7 @@ export const SiteDataSchemaList = props => (
 export const SiteDataSchemaCreate = props => (
     <Create {...props} title="SiteDataSchema Create">
         <SimpleForm validate={validationCreateSiteDataSchema}>
-            <ReferenceInput label="Site" source="site_id" reference="sites" allowEmpty>
+            <ReferenceInput label="Site" source="site_id" reference="sites" perPage={0} allowEmpty>
                 <SelectInput optionText="name" />
             </ReferenceInput>
             <LongTextInput source="schema" format={value => value instanceof Object ? JSON.stringify(value) : value} parse={value => { try { return JSON.parse(value); } catch (e) { return value; } }} />

--- a/admin/src/resources/SiteRole.js
+++ b/admin/src/resources/SiteRole.js
@@ -64,10 +64,10 @@ export const SiteRoleList = props => (
 export const SiteRoleCreate = props => (
     <Create {...props} title="SiteRole Create">
         <SimpleForm validate={validationCreateSiteRole}>
-            <ReferenceInput label="Site" source="site_id" reference="sites" allowEmpty>
+            <ReferenceInput label="Site" source="site_id" reference="sites" perPage={0} allowEmpty>
                 <SelectInput optionText="name" />
             </ReferenceInput>
-            <ReferenceInput label="Role" source="role_id" reference="roles" allowEmpty>
+            <ReferenceInput label="Role" source="role_id" reference="roles" perPage={0} allowEmpty>
                 <SelectInput optionText="label" />
             </ReferenceInput>
             <BooleanInput source="grant_implicitly" />

--- a/admin/src/resources/UserDomainRole.js
+++ b/admin/src/resources/UserDomainRole.js
@@ -60,13 +60,13 @@ export const UserDomainRoleList = props => (
 export const UserDomainRoleCreate = props => (
     <Create {...props} title="UserDomainRole Create">
         <SimpleForm validate={validationCreateUserDomainRole}>
-            <ReferenceInput label="User" source="user_id" reference="users" allowEmpty>
+            <ReferenceInput label="User" source="user_id" reference="users" perPage={0} allowEmpty>
                 <SelectInput optionText="username" />
             </ReferenceInput>
-            <ReferenceInput label="Domain" source="domain_id" reference="domains" allowEmpty>
+            <ReferenceInput label="Domain" source="domain_id" reference="domains" perPage={0} allowEmpty>
                 <SelectInput optionText="name" />
             </ReferenceInput>
-            <ReferenceInput label="Role" source="role_id" reference="roles" allowEmpty>
+            <ReferenceInput label="Role" source="role_id" reference="roles" perPage={0} allowEmpty>
                 <SelectInput optionText="label" />
             </ReferenceInput>
         </SimpleForm>

--- a/admin/src/resources/UserSiteData.js
+++ b/admin/src/resources/UserSiteData.js
@@ -75,10 +75,10 @@ export const UserSiteDataList = props => (
 export const UserSiteDataCreate = props => (
     <Create {...props} title="UserSiteData Create">
         <SimpleForm validate={validationCreateUserSiteData}>
-            <ReferenceInput label="User" source="user_id" reference="users" allowEmpty>
+            <ReferenceInput label="User" source="user_id" reference="users" perPage={0} allowEmpty>
                 <SelectInput optionText="username" />
             </ReferenceInput>
-            <ReferenceInput label="Site" source="site_id" reference="sites" allowEmpty>
+            <ReferenceInput label="Site" source="site_id" reference="sites" perPage={0} allowEmpty>
                 <SelectInput optionText="name" />
             </ReferenceInput>
             <DateTimeInput source="consented_at" />

--- a/admin/src/resources/UserSiteRole.js
+++ b/admin/src/resources/UserSiteRole.js
@@ -60,13 +60,13 @@ export const UserSiteRoleList = props => (
 export const UserSiteRoleCreate = props => (
     <Create {...props} title="UserSiteRole Create">
         <SimpleForm validate={validationCreateUserSiteRole}>
-            <ReferenceInput label="User" source="user_id" reference="users" allowEmpty>
+            <ReferenceInput label="User" source="user_id" reference="users" perPage={0} allowEmpty>
                 <SelectInput optionText="username" />
             </ReferenceInput>
-            <ReferenceInput label="Site" source="site_id" reference="sites" allowEmpty>
+            <ReferenceInput label="Site" source="site_id" reference="sites" perPage={0} allowEmpty>
                 <SelectInput optionText="name" />
             </ReferenceInput>
-            <ReferenceInput label="Role" source="role_id" reference="roles" allowEmpty>
+            <ReferenceInput label="Role" source="role_id" reference="roles" perPage={0} allowEmpty>
                 <SelectInput optionText="label" />
             </ReferenceInput>
         </SimpleForm>

--- a/admin/src/swaggerRestServer.js
+++ b/admin/src/swaggerRestServer.js
@@ -54,8 +54,10 @@ export const convertRESTRequestToHTTP = ({
         case GET_LIST: {
             if (params.pagination) {
                 const { page, perPage } = params.pagination;
-                query['limit'] = perPage;
-                query['offset'] = (page - 1) * perPage;
+                if (perPage > 0) {
+                    query['limit'] = perPage;
+                    query['offset'] = (page - 1) * perPage;
+                }
             }
 
             if (params.sort) {


### PR DESCRIPTION
The default `perPage` limit of the reference input was 25 which current cuts off a lot of users. Therefore using the generated code the `perPage` on each ReferenceInput is set to `0` which is then picked up in the swaggerRestServer as `no limit`.