### PR TITLE
Change/more generated filters

### DIFF
--- a/admin/src/filters/UserFilter.js
+++ b/admin/src/filters/UserFilter.js
@@ -5,14 +5,33 @@
 import React from 'react';
 import {
     TextInput,
+    BooleanInput,
+    NumberInput,
     Filter
 } from 'admin-on-rest';
 
 export const UserFilter = props => (
     <Filter {...props}>
-        <TextInput label="Search" source="q" alwaysOn />
+	<TextInput label="Search" source="q" alwaysOn />
+        <TextInput label="Birth Date" source="birth_date" />
+        <TextInput label="Country" source="country" />
+        <TextInput label="Date Joined" source="date_joined" />
         <TextInput label="Email" source="email" />
-        <TextInput label="Username Prefix" source="username_prefix" />
+        <BooleanInput label="Email Verified" source="email_verified" />
+        <TextInput label="First Name" source="first_name" />
+        <TextInput label="Gender" source="gender" />
+        <BooleanInput label="Is Active" source="is_active" />
+        <TextInput label="Last Login" source="last_login" />
+        <TextInput label="Last Name" source="last_name" />
+        <TextInput label="Msisdn" source="msisdn" />
+        <BooleanInput label="Msisdn Verified" source="msisdn_verified" />
+        <TextInput label="Nickname" source="nickname" />
+        <NumberInput label="Organisational Unit Id" source="organisational_unit_id" />
+        <TextInput label="Updated At" source="updated_at" />
+        <TextInput label="Username" source="username" />
+        <TextInput label="Q" source="q" />
+        <BooleanInput label="Tfa Enabled" source="tfa_enabled" />
+        <BooleanInput label="Has Organisational Unit" source="has_organisational_unit" />
     </Filter>
 );
 /** End of Generated Code **/

--- a/admin/src/filters/UserFilter.js
+++ b/admin/src/filters/UserFilter.js
@@ -9,28 +9,28 @@ import {
     NumberInput,
     Filter
 } from 'admin-on-rest';
+import DateRangeInput from '../inputs/DateRangeInput';
 
 export const UserFilter = props => (
     <Filter {...props}>
-	<TextInput label="Search" source="q" alwaysOn />
-        <TextInput label="Birth Date" source="birth_date" />
+	    <TextInput label="Search" source="q" alwaysOn />
+        <DateRangeInput label="Birth Date" source="birth_date" />
         <TextInput label="Country" source="country" />
-        <TextInput label="Date Joined" source="date_joined" />
+        <DateRangeInput label="Date Joined" source="date_joined" />
         <TextInput label="Email" source="email" />
         <BooleanInput label="Email Verified" source="email_verified" />
         <TextInput label="First Name" source="first_name" />
         <TextInput label="Gender" source="gender" />
         <BooleanInput label="Is Active" source="is_active" />
-        <TextInput label="Last Login" source="last_login" />
+        <DateRangeInput label="Last Login" source="last_login" />
         <TextInput label="Last Name" source="last_name" />
         <TextInput label="Msisdn" source="msisdn" />
         <BooleanInput label="Msisdn Verified" source="msisdn_verified" />
         <TextInput label="Nickname" source="nickname" />
-        <NumberInput label="Organisational Unit Id" source="organisational_unit_id" />
-        <TextInput label="Updated At" source="updated_at" />
+        <NumberInput label="Organisational Unit ID" source="organisational_unit_id" />
+        <DateRangeInput label="Updated At" source="updated_at" time />
         <TextInput label="Username" source="username" />
-        <TextInput label="Q" source="q" />
-        <BooleanInput label="Tfa Enabled" source="tfa_enabled" />
+        <BooleanInput label="Three factor Auth Enabled" source="tfa_enabled" />
         <BooleanInput label="Has Organisational Unit" source="has_organisational_unit" />
     </Filter>
 );

--- a/admin/src/inputs/AutocompleteInput.js
+++ b/admin/src/inputs/AutocompleteInput.js
@@ -17,17 +17,27 @@ import { FieldTitle, translate } from 'admin-on-rest';
  **/
 
 export class AutocompleteInput extends Component {
-    state = { menuDisabled: true };
+    constructor(props) {
+        super(props);
+        this.state = {
+            menuDisabled: true
+        };
+        this.handleOnBlur = this.handleOnBlur.bind(this);
+        this.handleNewRequest = this.handleNewRequest.bind(this);
+        this.handleUpdateInput = this.handleUpdateInput.bind(this);
+        this.getSuggestion = this.getSuggestion.bind(this);
+        this.setSearchText = this.setSearchText.bind(this);
+    }
 
     componentWillMount() {
         this.setSearchText(this.props);
     }
 
-    handleOnBlur = (args) => {
+    handleOnBlur() {
         this.setSearchText(this.props);
     }
 
-    handleNewRequest = (chosenRequest, index) => {
+    handleNewRequest(chosenRequest, index) {
         if (index !== -1) {
             const { choices, input, optionValue } = this.props;
             const selectedSource = choices[index];
@@ -36,7 +46,7 @@ export class AutocompleteInput extends Component {
         }
     };
 
-    handleUpdateInput = searchText => {
+    handleUpdateInput(searchText) {
         this.setState({ text: searchText, menuDisabled: true });
         if (searchText.length >= 3) {
             this.setState({ menuDisabled: false });

--- a/admin/src/inputs/DateRangeInput.js
+++ b/admin/src/inputs/DateRangeInput.js
@@ -1,0 +1,68 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { Field } from 'redux-form';
+import { DateInput } from 'admin-on-rest';
+import DateTimeInput from 'aor-datetime-input';
+
+const COMPONENTS = {
+    date: DateInput,
+    datetime: DateTimeInput
+};
+
+class DateRangeInput extends Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            from: '',
+            to: ''
+        };
+        this.component = props.time ? COMPONENTS.datetime : COMPONENTS.date;
+        this.handleFromOnChange = this.handleFromOnChange.bind(this);
+        this.handleToOnChange = this.handleToOnChange.bind(this);
+    }
+
+    handleFromOnChange(event, value) {
+        this.setState({ from: value });
+    }
+
+    handleToOnChange(event, value) {
+        this.setState({ to: value });
+    }
+
+    render() {
+        const { source } = this.props;
+        return (
+            <span>
+                <Field
+                    name={`${source}.from`}
+                    component={this.component}
+                    props={{
+                        options: {
+                            maxDate: new Date(this.state.to)
+                        }
+                    }}
+                    label="From"
+                    onChange={this.handleFromOnChange}
+                />
+                <Field
+                    name={`${source}.to`}
+                    component={this.component}
+                    props={{
+                        options: {
+                            minDate: new Date(this.state.from)
+                        }
+                    }}
+                    label="To"
+                    onChange={this.handleToOnChange}
+                />
+            </span>
+        );
+    }
+}
+DateRangeInput.propTypes = {
+    time: PropTypes.bool
+};
+DateRangeInput.defaultProps = {
+    time: false
+};
+export default DateRangeInput;

--- a/admin/src/inputs/DateRangeInput.js
+++ b/admin/src/inputs/DateRangeInput.js
@@ -31,6 +31,15 @@ class DateRangeInput extends Component {
 
     render() {
         const { source } = this.props;
+        const today = new Date();
+        const maxDate =
+            this.state.to !== ''
+                ? new Date(this.state.to)
+                : new Date(today.getFullYear() + 100, today.getMonth(), today.getDay());
+        const minDate =
+            this.state.from !== ''
+                ? new Date(this.state.from)
+                : new Date(today.getFullYear() - 100, today.getMonth(), today.getDay());
         return (
             <span>
                 <Field
@@ -38,7 +47,7 @@ class DateRangeInput extends Component {
                     component={this.component}
                     props={{
                         options: {
-                            maxDate: new Date(this.state.to)
+                            maxDate: maxDate
                         }
                     }}
                     label="From"
@@ -49,7 +58,7 @@ class DateRangeInput extends Component {
                     component={this.component}
                     props={{
                         options: {
-                            minDate: new Date(this.state.from)
+                            minDate: minDate
                         }
                     }}
                     label="To"

--- a/admin/src/inputs/DateRangeInput.js
+++ b/admin/src/inputs/DateRangeInput.js
@@ -32,35 +32,43 @@ class DateRangeInput extends Component {
     render() {
         const { source } = this.props;
         const today = new Date();
-        const maxDate =
-            this.state.to !== ''
-                ? new Date(this.state.to)
-                : new Date(today.getFullYear() + 100, today.getMonth(), today.getDay());
-        const minDate =
-            this.state.from !== ''
-                ? new Date(this.state.from)
-                : new Date(today.getFullYear() - 100, today.getMonth(), today.getDay());
+        const fromProps = {
+            options: {
+                maxDate:
+                    this.state.to !== ''
+                        ? new Date(this.state.to)
+                        : new Date(
+                              today.getFullYear() + 100,
+                              today.getMonth(),
+                              today.getDay()
+                          )
+            }
+        };
+        const toProps = {
+            options: {
+                minDate:
+                    this.state.from !== ''
+                        ? new Date(this.state.from)
+                        : new Date(
+                              today.getFullYear() - 100,
+                              today.getMonth(),
+                              today.getDay()
+                          )
+            }
+        };
         return (
             <span>
                 <Field
                     name={`${source}.from`}
                     component={this.component}
-                    props={{
-                        options: {
-                            maxDate: maxDate
-                        }
-                    }}
+                    props={fromProps}
                     label="From"
                     onChange={this.handleFromOnChange}
                 />
                 <Field
                     name={`${source}.to`}
                     component={this.component}
-                    props={{
-                        options: {
-                            minDate: minDate
-                        }
-                    }}
+                    props={toProps}
                     label="To"
                     onChange={this.handleToOnChange}
                 />

--- a/admin/src/inputs/DateRangeInput.js
+++ b/admin/src/inputs/DateRangeInput.js
@@ -13,8 +13,8 @@ class DateRangeInput extends Component {
     constructor(props) {
         super(props);
         this.state = {
-            from: '',
-            to: ''
+            from: this.props.input.value.from,
+            to: this.props.input.value.to
         };
         this.component = props.time ? COMPONENTS.datetime : COMPONENTS.date;
         this.handleFromOnChange = this.handleFromOnChange.bind(this);

--- a/admin/src/resources/Role.js
+++ b/admin/src/resources/Role.js
@@ -29,9 +29,6 @@ const validationCreateRole = values => {
     if (!values.label) {
         errors.label = ["label is required"];
     }
-    if (!values.requires_2fa) {
-        errors.requires_2fa = ["requires_2fa is required"];
-    }
     return errors;
 }
 

--- a/admin/src/swaggerRestServer.js
+++ b/admin/src/swaggerRestServer.js
@@ -66,10 +66,14 @@ export const convertRESTRequestToHTTP = ({
 
             if (params.filter) {
                 Object.keys(params.filter).forEach(key => {
-                    query[key] =
+                    let filter =
                         params.filter[key] instanceof Object
                             ? JSON.stringify(params.filter[key])
                             : params.filter[key];
+                    // API filters work on trigrams, therefore only add on 3 characters or more.
+                    if (filter.length > 2) {
+                        query[key] = filter;
+                    }
                 });
             }
 

--- a/admin/src/swaggerRestServer.js
+++ b/admin/src/swaggerRestServer.js
@@ -66,7 +66,10 @@ export const convertRESTRequestToHTTP = ({
 
             if (params.filter) {
                 Object.keys(params.filter).forEach(key => {
-                    query[key] = params.filter[key];
+                    query[key] =
+                        params.filter[key] instanceof Object
+                            ? JSON.stringify(params.filter[key])
+                            : params.filter[key];
                 });
             }
 

--- a/swagger/management_layer.yml
+++ b/swagger/management_layer.yml
@@ -374,11 +374,11 @@ definitions:
         $ref: '#/definitions/role_label'
       requires_2fa:
         type: boolean
+        default: true
       description:
         type: string
     required:
       - label
-      - requires_2fa
 
   role_update:
     type: object
@@ -1377,6 +1377,62 @@ definitions:
         maxLength: 2
     minProperties: 1
 
+  resource_permission:
+    type: object
+    properties:
+      resource:
+        type: string
+        format: uri
+      permission:
+        type: string
+    required:
+      - resource
+      - permission
+
+  user_permissions_check:
+    type: object
+    properties:
+      operator:
+        type: string
+        enum: [all, any]
+      resource_permissions:
+        type: array
+        items:
+          $ref: '#/definitions/resource_permission'
+      site_id:
+        type: integer
+      domain_id:
+        type: integer
+      nocache:
+        type: boolean
+        default: false
+    required:
+      - operator
+      - resource_permissions
+      # site_id or domain_id is required
+
+  user_permissions_check_response:
+    type: object
+    properties:
+      has_permissions:
+        type: boolean
+    required:
+      - has_permissions
+
+  user_with_roles:
+    description: 'A user with their roles.'
+    type: object
+    properties:
+      id:
+        type: string
+        format: uuid
+      username:
+        type: string
+      roles:
+        type: array
+        items:
+          type: string
+
 paths:
   /refresh/all:
     parameters:
@@ -1392,6 +1448,20 @@ paths:
         403:
          description: "Forbidden"
 
+  /refresh/clients:
+    parameters:
+      - $ref: '#/parameters/optional_nocache'
+    get:
+      description: "Refresh OIDC client information"
+      operationId: refresh_clients
+      produces:
+        - application/json
+      responses:
+        200:
+          description: "Successfully refreshed OIDC client data"
+        403:
+         description: "Forbidden"
+
   /refresh/domains:
     parameters:
       - $ref: '#/parameters/optional_nocache'
@@ -1403,6 +1473,20 @@ paths:
       responses:
         200:
           description: "Successfully refreshed domain mapping data"
+        403:
+         description: "Forbidden"
+
+  /refresh/keys:
+    parameters:
+      - $ref: '#/parameters/optional_nocache'
+    get:
+      description: "Refresh JWKS information"
+      operationId: refresh_keys
+      produces:
+        - application/json
+      responses:
+        200:
+          description: "Successfully refreshed keys data"
         403:
          description: "Forbidden"
 
@@ -1550,6 +1634,78 @@ paths:
             $ref: '#/definitions/all_user_roles'
         403:
           description: 'Forbidden'
+        404:
+          description: 'User not found'
+      tags:
+        - operational
+
+  /ops/users_with_roles_for_domain/{domain_id}:
+    parameters:
+      - $ref: '#/parameters/domain_id'
+    get:
+      description: 'Get a list of Users with their effective roles within the given domain.'
+      operationId: get_users_with_roles_for_domain
+      produces:
+        - application/json
+      responses:
+        200:
+          description: ''
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/user_with_roles'
+        403:
+          description: 'Forbidden'
+        404:
+          description: 'Domain not found'
+      tags:
+        - operational
+
+  /ops/users_with_roles_for_site/{site_id}:
+    parameters:
+      - $ref: '#/parameters/site_id'
+    get:
+      description: 'Get a list of Users with their effective roles within the given site.'
+      operationId: get_users_with_roles_for_site
+      produces:
+        - application/json
+      responses:
+        200:
+          description: ''
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/user_with_roles'
+        403:
+          description: 'Forbidden'
+        404:
+          description: 'Site not found'
+      tags:
+        - operational
+
+  /ops/user_has_permissions/{user_id}:
+    parameters:
+      - $ref: '#/parameters/user_id'
+      - in: body
+        name: data
+        schema:
+          $ref: '#/definitions/user_permissions_check'
+    post:
+      description: 'Check of the user has the specified resource permissions'
+      operationId: user_has_permissions
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      responses:
+        200:
+          description: 'True if the user has the permissions, else False'
+          schema:
+            $ref: '#/definitions/user_permissions_check_response'
+        403:
+          description: 'Forbidden'
+        400:
+          description: 'Bad Request'
         404:
           description: 'User not found'
       tags:
@@ -2930,7 +3086,7 @@ paths:
               $ref: '#/definitions/client'
 
       tags:
-        - oidc_provider
+        - authentication
 
   /clients/{client_id}:
     parameters:
@@ -2953,17 +3109,120 @@ paths:
       parameters:
         - $ref: '#/parameters/optional_offset'
         - $ref: '#/parameters/optional_limit'
+        - name: birth_date
+          description: An optional birth_date range filter
+          in: query
+          required: false
+          type: string
+        - name: country
+          description: An optional country filter
+          in: query
+          required: false
+          type: string
+          minLength: 2
+          maxLength: 2
+        - name: date_joined
+          description: An optional date joined range filter
+          in: query
+          required: false
+          type: string
         - name: email
-          description: An optional email filter
+          description: An optional case insensitive email inner match filter
           in: query
           required: false
           type: string
-          format: email
-        - name: username_prefix
-          description: An optional username prefix filter
+          minLength: 3
+        - name: email_verified
+          description: An optional email verified filter
+          in: query
+          required: false
+          type: boolean
+        - name: first_name
+          description: An optional case insensitive first name inner match filter
           in: query
           required: false
           type: string
+          minLength: 3
+        - name: gender
+          description: An optional gender filter
+          in: query
+          required: false
+          type: string
+        - name: is_active
+          description: An optional is_active filter
+          in: query
+          required: false
+          type: boolean
+        - name: last_login
+          description: An optional last login range filter
+          in: query
+          required: false
+          type: string
+        - name: last_name
+          description: An optional case insensitive last name inner match filter
+          in: query
+          required: false
+          type: string
+          minLength: 3
+        - name: msisdn
+          description: An optional case insensitive MSISDN inner match filter
+          in: query
+          required: false
+          type: string
+          minLength: 3
+        - name: msisdn_verified
+          description: An optional MSISDN verified filter
+          in: query
+          required: false
+          type: boolean
+        - name: nickname
+          description: An optional case insensitive nickname inner match filter
+          in: query
+          required: false
+          type: string
+          minLength: 3
+        - name: organisational_unit_id
+          description: An optional filter on the organisational unit id
+          in: query
+          required: false
+          type: integer
+        - name: updated_at
+          description: An optional updated_at range filter
+          in: query
+          required: false
+          type: string
+        - name: username
+          description: An optional case insensitive username inner match filter
+          in: query
+          required: false
+          type: string
+          minLength: 3
+        - name: q
+          description: An optional case insensitive inner match filter across all searchable text fields
+          in: query
+          required: false
+          type: string
+          minLength: 3
+        - name: tfa_enabled
+          description: An optional filter based on whether a user has 2FA enabled or not
+          in: query
+          required: false
+          type: boolean
+        - name: has_organisational_unit
+          description: An optional filter based on whether a user has an organisational unit or not
+          in: query
+          required: false
+          type: boolean
+        - name: order_by
+          description: Fields and directions to order by, e.g. "-created_at,username". Add "-" in front
+            of a field name to indicate descending order.
+          in: query
+          required: false
+          type: array
+          collectionFormat: csv
+          items:
+            type: string
+          uniqueItems: true
         - name: user_ids
           description: An optional list of user ids
           in: query
@@ -2989,7 +3248,7 @@ paths:
             items:
               $ref: '#/definitions/user'
       tags:
-        - oidc_provider
+        - authentication
 
   '/users/{user_id}':
     parameters:
@@ -3000,7 +3259,7 @@ paths:
         '204':
           description: ''
       tags:
-        - oidc_provider
+        - authentication
     get:
       operationId: user_read
       produces:
@@ -3011,7 +3270,7 @@ paths:
           schema:
             $ref: '#/definitions/user'
       tags:
-        - oidc_provider
+        - authentication
 
     put:
       consumes:
@@ -3027,8 +3286,10 @@ paths:
       responses:
         '200':
           description: ''
+          schema:
+            $ref: '#/definitions/user'
       tags:
-        - oidc_provider
+        - authentication
 
   '/users/{user_id}/activate':
     parameters:


### PR DESCRIPTION
*Background*: Needed a DateRange filter for some of the new user filter items, and a lot more filters were added to the swagger specification for the user list endpoint.

*What was done*: A dateRangeInput was implemented with the ability to use datetime if required. DateInputs are limited by on another in order to avoid overlapping dates. 

EDIT: Also added in requirement that filters only fire off on 3 characters or more, as the API's return require a minimum of 3 for each filter.