### PR TITLE
Minor/query lengths

### DIFF
--- a/admin/src/filters/UserFilter.js
+++ b/admin/src/filters/UserFilter.js
@@ -13,7 +13,7 @@ import DateRangeInput from '../inputs/DateRangeInput';
 
 export const UserFilter = props => (
     <Filter {...props}>
-	    <TextInput label="Search" source="q" alwaysOn />
+	<TextInput label="Search" source="q" alwaysOn />
         <DateRangeInput label="Birth Date" source="birth_date" />
         <TextInput label="Country" source="country" />
         <DateRangeInput label="Date Joined" source="date_joined" />
@@ -30,7 +30,7 @@ export const UserFilter = props => (
         <NumberInput label="Organisational Unit ID" source="organisational_unit_id" />
         <DateRangeInput label="Updated At" source="updated_at" time />
         <TextInput label="Username" source="username" />
-        <BooleanInput label="Three factor Auth Enabled" source="tfa_enabled" />
+        <BooleanInput label="Two factor Auth Enabled" source="tfa_enabled" />
         <BooleanInput label="Has Organisational Unit" source="has_organisational_unit" />
     </Filter>
 );

--- a/admin/src/inputs/DateRangeInput.js
+++ b/admin/src/inputs/DateRangeInput.js
@@ -1,3 +1,7 @@
+/** 
+ * Generated DateRangeInput.js code. Edit at own risk.
+ * When regenerated the changes will be lost.
+**/
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Field } from 'redux-form';
@@ -83,3 +87,4 @@ DateRangeInput.defaultProps = {
     time: false
 };
 export default DateRangeInput;
+/** End of Generated Code **/

--- a/admin/src/swaggerRestServer.js
+++ b/admin/src/swaggerRestServer.js
@@ -31,14 +31,31 @@ const PK_MAPPING = {
 
 const FILTER_LENGTHS = {
     users: {
-        country: 2,
-        email: 3,
-        first_name: 3,
-        last_name: 3,
-        msisdn: 3,
-        nickname: 3,
-        username: 3,
-        q: 3,
+        country: {
+            min: 2,
+            max: 2
+        },
+        email: {
+            min: 3,
+        },
+        first_name: {
+            min: 3,
+        },
+        last_name: {
+            min: 3,
+        },
+        msisdn: {
+            min: 3,
+        },
+        nickname: {
+            min: 3,
+        },
+        username: {
+            min: 3,
+        },
+        q: {
+            min: 3,
+        },
     },
 };
 
@@ -84,11 +101,17 @@ export const convertRESTRequestToHTTP = ({
                         params.filter[key] instanceof Object
                             ? JSON.stringify(params.filter[key])
                             : params.filter[key];
-                    let minLength =
-                        filterLengths && filterLengths[key]
-                            ? filterLengths[key]
-                            : 0;
-                    if (minLength === 0 || filter.length >= minLength) {
+                    if (filterLengths && filterLengths[key]) {
+                        const minLength = filterLengths[key].min;
+                        const maxLength = filterLengths[key].max;
+                        if (!minLength || filter.length >= minLength) {
+                            filter =
+                                maxLength && filter.length > maxLength
+                                    ? filter.slice(0, maxLength)
+                                    : filter;
+                            query[key] = filter;
+                        }
+                    } else {
                         query[key] = filter;
                     }
                 });

--- a/admin/src/swaggerRestServer.js
+++ b/admin/src/swaggerRestServer.js
@@ -29,6 +29,19 @@ const PK_MAPPING = {
     sitedataschemas: 'site_id'
 };
 
+const FILTER_LENGTHS = {
+    users: {
+        country: 2,
+        email: 3,
+        first_name: 3,
+        last_name: 3,
+        msisdn: 3,
+        nickname: 3,
+        username: 3,
+        q: 3,
+    },
+};
+
 /**
  * @param {String} apiUrl The base API url
  * @param {String} type One of the constants appearing at the top if this file, e.g. 'UPDATE'
@@ -65,13 +78,17 @@ export const convertRESTRequestToHTTP = ({
             }
 
             if (params.filter) {
+                let filterLengths = FILTER_LENGTHS[resource];
                 Object.keys(params.filter).forEach(key => {
                     let filter =
                         params.filter[key] instanceof Object
                             ? JSON.stringify(params.filter[key])
                             : params.filter[key];
-                    // API filters work on trigrams, therefore only add on 3 characters or more.
-                    if (filter.length > 2) {
+                    let minLength =
+                        filterLengths && filterLengths[key]
+                            ? filterLengths[key]
+                            : 0;
+                    if (minLength === 0 || filter.length >= minLength) {
                         query[key] = filter;
                     }
                 });

--- a/swagger/management_layer.yml
+++ b/swagger/management_layer.yml
@@ -3114,6 +3114,9 @@ paths:
           in: query
           required: false
           type: string
+          x-aor-filter:
+            format: date
+            range: true
         - name: country
           description: An optional country filter
           in: query
@@ -3126,6 +3129,9 @@ paths:
           in: query
           required: false
           type: string
+          x-aor-filter:
+            format: date
+            range: true
         - name: email
           description: An optional case insensitive email inner match filter
           in: query
@@ -3158,6 +3164,9 @@ paths:
           in: query
           required: false
           type: string
+          x-aor-filter:
+            format: date
+            range: true
         - name: last_name
           description: An optional case insensitive last name inner match filter
           in: query
@@ -3191,6 +3200,9 @@ paths:
           in: query
           required: false
           type: string
+          x-aor-filter:
+            format: date-time
+            range: true
         - name: username
           description: An optional case insensitive username inner match filter
           in: query


### PR DESCRIPTION
*background*: There are possibilities where specific filter parameters have specific min and max input values on the API.

*what was done*: Using the swagger-aor-generator, all the query fields for the filters with min and max input values are listed and handling in the swaggerRestClient for the management portal. Also updated the swagger specification with all the daterangeinputs for the generation to be correct for daterange fields.