### PR TITLE
Feature/selected fields

### DIFF
--- a/admin/src/Theme.js
+++ b/admin/src/Theme.js
@@ -55,5 +55,9 @@ export const styles = {
     },
     circularProgress: {
         padding: '50px'
+    },
+    fieldOptionsCard: {
+        margin: '20px',
+        width: '30rem'
     }
 };

--- a/admin/src/catchAll.js
+++ b/admin/src/catchAll.js
@@ -8,9 +8,13 @@ import { NotFound } from 'admin-on-rest';
 
 class catchAll extends Component {
     render() {
-        return localStorage.getItem('id_token') ? <NotFound /> : <Redirect push to="/login" />
+        return localStorage.getItem('id_token') ? (
+            <NotFound />
+        ) : (
+            <Redirect push to="/login" />
+        );
     }
-};
+}
 
 export default catchAll;
 /** End of Generated Code **/

--- a/admin/src/grids/FieldSelectDatagrid.js
+++ b/admin/src/grids/FieldSelectDatagrid.js
@@ -20,22 +20,20 @@ class FieldSelectDatagrid extends Component {
     componentWillMount() {
         // Here we setup the state of all checkboxes for showing/hiding each fields.
         const { children, defaultHiddenFields } = this.props;
+        const hiddenSet = new Set(defaultHiddenFields);
         if (children && !this.state.checkboxes) {
             // Create all checkboxes in state with their default value if given in props.
             const checkboxes = children.reduce((obj, field) => {
                 if (field.props && field.props.source) {
-                    obj[field.props.source] =
-                        defaultHiddenFields[field.props.source] != null
-                            ? defaultHiddenFields[field.props.source]
-                            : true;
+                    obj[field.props.source] = hiddenSet.has(field.props.source)
+                        ? false
+                        : true;
                     return obj;
                 }
                 return obj;
             }, {});
             // Check if all are not shown
-            const allHidden = Object.values(checkboxes).every(
-                value => !value
-            );
+            const allHidden = Object.values(checkboxes).every(value => !value);
             // Set the state with all the children that have false checkboxes omitted.
             this.setState({
                 checkboxes: checkboxes,
@@ -112,10 +110,10 @@ class FieldSelectDatagrid extends Component {
     }
 }
 FieldSelectDatagrid.propTypes = {
-    defaultHiddenFields: PropTypes.object
+    defaultHiddenFields: PropTypes.array
 };
 FieldSelectDatagrid.defaultProps = {
-    defaultHiddenFields: {}
+    defaultHiddenFields: []
 };
 
 export default FieldSelectDatagrid;

--- a/admin/src/listings/FieldSelectDatagrid.js
+++ b/admin/src/listings/FieldSelectDatagrid.js
@@ -1,8 +1,72 @@
-import React from 'react';
 import { Datagrid } from 'admin-on-rest';
+import React, { Component } from 'react';
+import CardText from 'material-ui/Card/CardText';
+import Checkbox from 'material-ui/Checkbox';
+import Visibility from 'material-ui/svg-icons/action/visibility';
+import VisibilityOff from 'material-ui/svg-icons/action/visibility-off';
 
-const FieldSelectDatagrid = props => {
-    return <div><span>test</span><Datagrid {...props}>{props.children}</Datagrid></div>;
-};
+class FieldSelectDatagrid extends Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            children: props.children
+        };
+    }
+
+    componentWillReceiveProps(nextProps, currentProps) {
+        // Here we setup the state of all checkboxes for showing/hiding each fields.
+        if (nextProps.ids && !this.state.checkboxes) {
+            const fields = Object.keys(Object.entries(nextProps.data)[0][1]);
+            this.setState({
+                checkboxes: fields.reduce((obj, field) => {
+                    obj[field] = true;
+                    return obj;
+                }, {})
+            });
+        }
+    }
+
+    updateCheckbox(name) {
+        // Toggle the given checkbox state value.
+        const nextCheckboxState = {
+            ...this.state.checkboxes,
+            [name]: !this.state.checkboxes[name]
+        };
+        this.setState({
+            checkboxes: nextCheckboxState,
+            children: this.props.children.map(child => {
+                return child.props
+                    ? nextCheckboxState[child.props.source]
+                        ? child
+                        : ''
+                    : child;
+            })
+        });
+    }
+
+    render() {
+        return this.state.checkboxes ? (
+            <div>
+                <CardText>
+                    {Object.entries(this.state.checkboxes).map(
+                        ([name, value]) => (
+                            <Checkbox
+                                key={name}
+                                label={name}
+                                checked={value}
+                                onCheck={() => this.updateCheckbox(name)}
+                                checkedIcon={<Visibility />}
+                                uncheckedIcon={<VisibilityOff />}
+                            />
+                        )
+                    )}
+                </CardText>
+                <Datagrid {...this.props}>{this.state.children}</Datagrid>
+            </div>
+        ) : (
+            <CardText>No results found</CardText>
+        );
+    }
+}
 
 export default FieldSelectDatagrid;

--- a/admin/src/listings/FieldSelectDatagrid.js
+++ b/admin/src/listings/FieldSelectDatagrid.js
@@ -1,0 +1,8 @@
+import React from 'react';
+import { Datagrid } from 'admin-on-rest';
+
+const FieldSelectDatagrid = props => {
+    return <div><span>test</span><Datagrid {...props}>{props.children}</Datagrid></div>;
+};
+
+export default FieldSelectDatagrid;

--- a/admin/src/listings/FieldSelectDatagrid.js
+++ b/admin/src/listings/FieldSelectDatagrid.js
@@ -1,9 +1,12 @@
 import { Datagrid } from 'admin-on-rest';
 import React, { Component } from 'react';
+import Card from 'material-ui/Card/Card';
+import CardHeader from 'material-ui/Card/CardHeader';
 import CardText from 'material-ui/Card/CardText';
 import Checkbox from 'material-ui/Checkbox';
 import Visibility from 'material-ui/svg-icons/action/visibility';
 import VisibilityOff from 'material-ui/svg-icons/action/visibility-off';
+import { styles } from '../Theme';
 
 class FieldSelectDatagrid extends Component {
     constructor(props) {
@@ -47,20 +50,27 @@ class FieldSelectDatagrid extends Component {
     render() {
         return this.state.checkboxes ? (
             <div>
-                <CardText>
-                    {Object.entries(this.state.checkboxes).map(
-                        ([name, value]) => (
-                            <Checkbox
-                                key={name}
-                                label={name}
-                                checked={value}
-                                onCheck={() => this.updateCheckbox(name)}
-                                checkedIcon={<Visibility />}
-                                uncheckedIcon={<VisibilityOff />}
-                            />
-                        )
-                    )}
-                </CardText>
+                <Card style={styles.fieldOptionsCard} >
+                    <CardHeader
+                        title="Hide/Show Fields"
+                        actAsExpander={true}
+                        showExpandableButton={true}
+                    />
+                    <CardText expandable={true}>
+                        {Object.entries(this.state.checkboxes).map(
+                            ([name, value]) => (
+                                <Checkbox
+                                    key={name}
+                                    label={name}
+                                    checked={value}
+                                    onCheck={() => this.updateCheckbox(name)}
+                                    checkedIcon={<Visibility />}
+                                    uncheckedIcon={<VisibilityOff />}
+                                />
+                            )
+                        )}
+                    </CardText>
+                </Card>
                 <Datagrid {...this.props}>{this.state.children}</Datagrid>
             </div>
         ) : (

--- a/admin/src/resources/User.js
+++ b/admin/src/resources/User.js
@@ -37,9 +37,11 @@ const validationEditUser = values => {
     return errors;
 }
 
+const hiddenFields = ['created_at', 'updated_at', 'avatar', 'country_code'];
+
 export const UserList = props => (
     <List {...props} title="User List" filters={<UserFilter />}>
-        <FieldSelectDatagrid bodyOptions={ { showRowHover: true } }>
+        <FieldSelectDatagrid defaultHiddenFields={hiddenFields} bodyOptions={ { showRowHover: true } }>
             <TextField source="id" />
             <TextField source="username" />
             <TextField source="first_name" />

--- a/admin/src/resources/User.js
+++ b/admin/src/resources/User.js
@@ -29,7 +29,7 @@ import {
 import {
     UserFilter
 } from '../filters/UserFilter';
-import FieldSelectDatagrid from '../listings/FieldSelectDatagrid';
+import FieldSelectDatagrid from '../grids/FieldSelectDatagrid';
 import permissionsStore from '../auth/PermissionsStore';
 
 const validationEditUser = values => {

--- a/admin/src/resources/User.js
+++ b/admin/src/resources/User.js
@@ -59,13 +59,8 @@ export const UserList = props => (
             <DateField source="updated_at" />
             {permissionsStore.getResourcePermission('users', 'edit') ? <EditButton /> : null}
             <ShowButton />
-<<<<<<< HEAD
-            <DeleteButton />
-        </FieldSelectDatagrid>
-=======
             {permissionsStore.getResourcePermission('users', 'remove') ? <DeleteButton />: null}
-        </Datagrid>
->>>>>>> 77b68ab6ce86fb295c4e0a81c33f6ba05735ea2d
+        </FieldSelectDatagrid>
     </List>
 )
 

--- a/admin/src/resources/User.js
+++ b/admin/src/resources/User.js
@@ -29,6 +29,7 @@ import {
 import {
     UserFilter
 } from '../filters/UserFilter';
+import FieldSelectDatagrid from '../listings/FieldSelectDatagrid';
 
 const validationEditUser = values => {
     const errors = {};
@@ -37,7 +38,7 @@ const validationEditUser = values => {
 
 export const UserList = props => (
     <List {...props} title="User List" filters={<UserFilter />}>
-        <Datagrid bodyOptions={ { showRowHover: true } }>
+        <FieldSelectDatagrid bodyOptions={ { showRowHover: true } }>
             <TextField source="id" />
             <TextField source="username" />
             <TextField source="first_name" />
@@ -58,7 +59,7 @@ export const UserList = props => (
             <EditButton />
             <ShowButton />
             <DeleteButton />
-        </Datagrid>
+        </FieldSelectDatagrid>
     </List>
 )
 


### PR DESCRIPTION
*Background*: The User model listing view has many fields and therefore the page is far too wide for good use. 

*What was done*: A custom AOR Datagrid component was made to add a show/hide field settings box. This setting box contains checkboxes of each field which hides all unwanted field columns in the list view. `defaultHiddenFields` props can be passed to this Datagrid component in order to hide desired fields by default. Some styling was added to the hide/show settings box and a video is given below.
[screenrec_00004.mp4.zip](https://github.com/girleffect/core-management-portal/files/2004259/screenrec_00004.mp4.zip)

