### PR TITLE
Feature/date range filter fixes

### DIFF
--- a/admin/src/inputs/DateRangeInput.js
+++ b/admin/src/inputs/DateRangeInput.js
@@ -1,12 +1,14 @@
-/** 
+/**
  * Generated DateRangeInput.js code. Edit at own risk.
  * When regenerated the changes will be lost.
-**/
+ **/
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Field } from 'redux-form';
 import { DateInput } from 'admin-on-rest';
 import DateTimeInput from 'aor-datetime-input';
+
+const timezoneOffset = new Date().getTimezoneOffset();
 
 const COMPONENTS = {
     date: DateInput,
@@ -33,31 +35,59 @@ class DateRangeInput extends Component {
         this.setState({ to: value });
     }
 
+    dateParser(value) {
+        const regexp = /(\d{4})-(\d{2})-(\d{2})/;
+        let match = regexp.exec(value);
+        if (match === null) return;
+
+        let year = match[1];
+        let month = match[2];
+        let day = match[3];
+
+        if (timezoneOffset < 0) {
+            // Negative offset means our picked UTC date got converted to previous day
+            var date = new Date(value);
+            date.setDate(date.getDate() + 1);
+            match = regexp.exec(date.toISOString());
+            year = match[1];
+            month = match[2];
+            day = match[3];
+        }
+        const correctDate = [year, month, day].join('-');
+
+        return correctDate;
+    }
+
+    dateTimeFormatter(value) {
+        if (timezoneOffset !== 0 && value) {
+            value = new Date(value);
+            value = new Date(value.valueOf() + timezoneOffset * 60000);
+        }
+        return value;
+    }
+
+    dateTimeParser(value) {
+        if (timezoneOffset !== 0 && value) {
+            value = new Date(value.valueOf() - timezoneOffset * 60000);
+        }
+        return value;
+    }
+
     render() {
-        const { source } = this.props;
+        const { source, time } = this.props;
         const today = new Date();
         const fromProps = {
             options: {
-                maxDate:
-                    this.state.to !== ''
-                        ? new Date(this.state.to)
-                        : new Date(
-                              today.getFullYear() + 100,
-                              today.getMonth(),
-                              today.getDay()
-                          )
+                maxDate: this.state.to
+                    ? new Date(this.state.to)
+                    : new Date(today.getFullYear() + 100, today.getMonth(), today.getDay())
             }
         };
         const toProps = {
             options: {
-                minDate:
-                    this.state.from !== ''
-                        ? new Date(this.state.from)
-                        : new Date(
-                              today.getFullYear() - 100,
-                              today.getMonth(),
-                              today.getDay()
-                          )
+                minDate: this.state.from
+                    ? new Date(this.state.from)
+                    : new Date(today.getFullYear() - 100, today.getMonth(), today.getDay())
             }
         };
         return (
@@ -67,6 +97,8 @@ class DateRangeInput extends Component {
                     component={this.component}
                     props={fromProps}
                     label="From"
+                    parse={time ? this.dateTimeParser : this.dateParser}
+                    format={time ? this.dateTimeFormatter : null}
                     onChange={this.handleFromOnChange}
                 />
                 <Field
@@ -74,6 +106,8 @@ class DateRangeInput extends Component {
                     component={this.component}
                     props={toProps}
                     label="To"
+                    parse={time ? this.dateTimeParser : this.dateParser}
+                    format={time ? this.dateTimeFormatter : null}
                     onChange={this.handleToOnChange}
                 />
             </span>

--- a/admin/src/inputs/DateRangeInput.js
+++ b/admin/src/inputs/DateRangeInput.js
@@ -36,6 +36,7 @@ class DateRangeInput extends Component {
     }
 
     dateParser(value) {
+        // Value recieved is a string in the DateInput.
         const regexp = /(\d{4})-(\d{2})-(\d{2})/;
         let match = regexp.exec(value);
         if (match === null) return;
@@ -59,6 +60,7 @@ class DateRangeInput extends Component {
     }
 
     dateTimeFormatter(value) {
+        // Value recieved is a date object in the DateTimeInput.
         if (timezoneOffset !== 0 && value) {
             value = new Date(value);
             value = new Date(value.valueOf() + timezoneOffset * 60000);
@@ -67,6 +69,7 @@ class DateRangeInput extends Component {
     }
 
     dateTimeParser(value) {
+        // Value recieved is a date object in the DateTimeInput.
         if (timezoneOffset !== 0 && value) {
             value = new Date(value.valueOf() - timezoneOffset * 60000);
         }


### PR DESCRIPTION
*Background*: The custom DateRangeInput using redux form fields which adjusts the time selection by the user's timezone (which is incorrect). Also trying to select the year with this custom component returned a blank list, thus making the year not easy to change.

*What was done*: A value parser was added for both date and date-time range filters in order to counter act the timezone adjustment. The date-time input component provides a date object to it's value parser and formatter which makes it easier to handle. Also to fix the year selection being empty, the initial minDate and maxDate values were `invalid date`s and thus were fixed by fixing the conditional.