### PR TITLE
Feature/more filter dropdowns

### DIFF
--- a/admin/src/constants.js
+++ b/admin/src/constants.js
@@ -13,6 +13,7 @@ export const TITLES = {
 
 export const PERMISSIONS = {
     manageuserroles: [
+        ['roles', 'list'],
         ['users', 'list'],
         ['sites', 'list'],
         ['siteroles', 'list'],

--- a/admin/src/filters/DomainFilter.js
+++ b/admin/src/filters/DomainFilter.js
@@ -4,10 +4,12 @@
 **/
 import React from 'react';
 import {
-    NumberInput,
+    SelectInput,
+    ReferenceInput,
     TextInput,
     Filter
 } from 'admin-on-rest';
+import UnlimitedDropdownInput from '../inputs/UnlimitedDropdownInput';
 
 const parseDomainIds = value => value.replace(/[^\w]/gi, ',');
 
@@ -22,7 +24,7 @@ const validateDomainIds = value => {
 
 const DomainFilter = props => (
     <Filter {...props}>
-        <NumberInput label="Parent Id" source="parent_id" />
+        <UnlimitedDropdownInput label="Parent" source="parent_id" reference="domains" optionText="name" />
         <TextInput label="Domain Ids" source="domain_ids" parse={parseDomainIds} validate={validateDomainIds} />
     </Filter>
 );

--- a/admin/src/filters/DomainRoleFilter.js
+++ b/admin/src/filters/DomainRoleFilter.js
@@ -7,10 +7,11 @@ import {
     NumberInput,
     Filter
 } from 'admin-on-rest';
+import UnlimitedDropdownInput from '../inputs/UnlimitedDropdownInput';
 
 const DomainRoleFilter = props => (
     <Filter {...props}>
-        <NumberInput label="Domain Id" source="domain_id" />
+        <UnlimitedDropdownInput label="Domain" source="domain_id" reference="domains" optionText="name" />
         <NumberInput label="Role Id" source="role_id" />
     </Filter>
 );

--- a/admin/src/filters/DomainRoleFilter.js
+++ b/admin/src/filters/DomainRoleFilter.js
@@ -4,7 +4,8 @@
 **/
 import React from 'react';
 import {
-    NumberInput,
+    SelectInput,
+    ReferenceInput,
     Filter
 } from 'admin-on-rest';
 import UnlimitedDropdownInput from '../inputs/UnlimitedDropdownInput';
@@ -12,7 +13,9 @@ import UnlimitedDropdownInput from '../inputs/UnlimitedDropdownInput';
 const DomainRoleFilter = props => (
     <Filter {...props}>
         <UnlimitedDropdownInput label="Domain" source="domain_id" reference="domains" optionText="name" />
-        <NumberInput label="Role Id" source="role_id" />
+        <ReferenceInput label="Role" source="role_id" reference="roles" allowEmpty>
+            <SelectInput optionText="label" />
+        </ReferenceInput>
     </Filter>
 );
 

--- a/admin/src/filters/InvitationDomainRoleFilter.js
+++ b/admin/src/filters/InvitationDomainRoleFilter.js
@@ -5,15 +5,19 @@
 import React from 'react';
 import {
     TextInput,
-    NumberInput,
+    SelectInput,
+    ReferenceInput,
     Filter
 } from 'admin-on-rest';
+import UnlimitedDropdownInput from '../inputs/UnlimitedDropdownInput';
 
 const InvitationDomainRoleFilter = props => (
     <Filter {...props}>
         <TextInput label="Invitation Id" source="invitation_id" />
-        <NumberInput label="Domain Id" source="domain_id" />
-        <NumberInput label="Role Id" source="role_id" />
+        <UnlimitedDropdownInput label="Domain" source="domain_id" reference="domains" optionText="name" />
+        <ReferenceInput label="Role" source="role_id" reference="roles" allowEmpty>
+            <SelectInput optionText="label" />
+        </ReferenceInput>
     </Filter>
 );
 

--- a/admin/src/filters/InvitationSiteRoleFilter.js
+++ b/admin/src/filters/InvitationSiteRoleFilter.js
@@ -5,15 +5,19 @@
 import React from 'react';
 import {
     TextInput,
-    NumberInput,
+    SelectInput,
+    ReferenceInput,
     Filter
 } from 'admin-on-rest';
+import UnlimitedDropdownInput from '../inputs/UnlimitedDropdownInput';
 
 const InvitationSiteRoleFilter = props => (
     <Filter {...props}>
         <TextInput label="Invitation Id" source="invitation_id" />
-        <NumberInput label="Site Id" source="site_id" />
-        <NumberInput label="Role Id" source="role_id" />
+        <UnlimitedDropdownInput label="Site" source="site_id" reference="sites" optionText="name" />
+        <ReferenceInput label="Role" source="role_id" reference="roles" allowEmpty>
+            <SelectInput optionText="label" />
+        </ReferenceInput>
     </Filter>
 );
 

--- a/admin/src/filters/RoleResourcePermissionFilter.js
+++ b/admin/src/filters/RoleResourcePermissionFilter.js
@@ -4,13 +4,17 @@
 **/
 import React from 'react';
 import {
+    SelectInput,
+    ReferenceInput,
     NumberInput,
     Filter
 } from 'admin-on-rest';
 
 const RoleResourcePermissionFilter = props => (
     <Filter {...props}>
-        <NumberInput label="Role Id" source="role_id" />
+        <ReferenceInput label="Role" source="role_id" reference="roles" allowEmpty>
+            <SelectInput optionText="label" />
+        </ReferenceInput>
         <NumberInput label="Resource Id" source="resource_id" />
         <NumberInput label="Permission Id" source="permission_id" />
     </Filter>

--- a/admin/src/filters/SiteRoleFilter.js
+++ b/admin/src/filters/SiteRoleFilter.js
@@ -4,14 +4,18 @@
 **/
 import React from 'react';
 import {
-    NumberInput,
+    SelectInput,
+    ReferenceInput,
     Filter
 } from 'admin-on-rest';
+import UnlimitedDropdownInput from '../inputs/UnlimitedDropdownInput';
 
 const SiteRoleFilter = props => (
     <Filter {...props}>
-        <NumberInput label="Site Id" source="site_id" />
-        <NumberInput label="Role Id" source="role_id" />
+        <UnlimitedDropdownInput label="Site" source="site_id" reference="sites" optionText="name" />
+        <ReferenceInput label="Role" source="role_id" reference="roles" allowEmpty>
+            <SelectInput optionText="label" />
+        </ReferenceInput>
     </Filter>
 );
 

--- a/admin/src/filters/UserDomainRoleFilter.js
+++ b/admin/src/filters/UserDomainRoleFilter.js
@@ -5,15 +5,19 @@
 import React from 'react';
 import {
     TextInput,
-    NumberInput,
+    SelectInput,
+    ReferenceInput,
     Filter
 } from 'admin-on-rest';
+import UnlimitedDropdownInput from '../inputs/UnlimitedDropdownInput';
 
 const UserDomainRoleFilter = props => (
     <Filter {...props}>
         <TextInput label="User Id" source="user_id" />
-        <NumberInput label="Domain Id" source="domain_id" />
-        <NumberInput label="Role Id" source="role_id" />
+        <UnlimitedDropdownInput label="Domain" source="domain_id" reference="domains" optionText="name" />
+        <ReferenceInput label="Role" source="role_id" reference="roles" allowEmpty>
+            <SelectInput optionText="label" />
+        </ReferenceInput>
     </Filter>
 );
 

--- a/admin/src/filters/UserFilter.js
+++ b/admin/src/filters/UserFilter.js
@@ -4,11 +4,11 @@
 **/
 import React from 'react';
 import {
+    SelectInput,
+    ReferenceInput,
     TextInput,
     BooleanInput,
     NumberInput,
-    ReferenceInput,
-    SelectInput,
     Filter
 } from 'admin-on-rest';
 import DateRangeInput from '../inputs/DateRangeInput';

--- a/admin/src/filters/UserFilter.js
+++ b/admin/src/filters/UserFilter.js
@@ -12,6 +12,7 @@ import {
     Filter
 } from 'admin-on-rest';
 import DateRangeInput from '../inputs/DateRangeInput';
+import UnlimitedDropdownInput from '../inputs/UnlimitedDropdownInput';
 
 const parseUserIds = value => value.replace(/[^\w]/gi, ',');
 
@@ -39,9 +40,7 @@ const UserFilter = props => (
         <BooleanInput label="Two factor Auth Enabled" source="tfa_enabled" />
         <BooleanInput label="Has Organisational Unit" source="has_organisational_unit" />
         <TextInput label="User Ids" source="user_ids" parse={parseUserIds} />
-        <ReferenceInput label="Site" source="site_ids" reference="sites" allowEmpty>
-            <SelectInput optionText="name" />
-        </ReferenceInput>
+        <UnlimitedDropdownInput label="Site" source="site_ids" reference="sites" optionText="name" />
     </Filter>
 );
 

--- a/admin/src/filters/UserSiteDataFilter.js
+++ b/admin/src/filters/UserSiteDataFilter.js
@@ -5,14 +5,16 @@
 import React from 'react';
 import {
     TextInput,
-    NumberInput,
+    SelectInput,
+    ReferenceInput,
     Filter
 } from 'admin-on-rest';
+import UnlimitedDropdownInput from '../inputs/UnlimitedDropdownInput';
 
 const UserSiteDataFilter = props => (
     <Filter {...props}>
         <TextInput label="User Id" source="user_id" />
-        <NumberInput label="Site Id" source="site_id" />
+        <UnlimitedDropdownInput label="Site" source="site_id" reference="sites" optionText="name" />
     </Filter>
 );
 

--- a/admin/src/filters/UserSiteRoleFilter.js
+++ b/admin/src/filters/UserSiteRoleFilter.js
@@ -5,15 +5,19 @@
 import React from 'react';
 import {
     TextInput,
-    NumberInput,
+    SelectInput,
+    ReferenceInput,
     Filter
 } from 'admin-on-rest';
+import UnlimitedDropdownInput from '../inputs/UnlimitedDropdownInput';
 
 const UserSiteRoleFilter = props => (
     <Filter {...props}>
         <TextInput label="User Id" source="user_id" />
-        <NumberInput label="Site Id" source="site_id" />
-        <NumberInput label="Role Id" source="role_id" />
+        <UnlimitedDropdownInput label="Site" source="site_id" reference="sites" optionText="name" />
+        <ReferenceInput label="Role" source="role_id" reference="roles" allowEmpty>
+            <SelectInput optionText="label" />
+        </ReferenceInput>
     </Filter>
 );
 

--- a/admin/src/inputs/UnlimitedDropdownInput.js
+++ b/admin/src/inputs/UnlimitedDropdownInput.js
@@ -13,8 +13,8 @@ class UnlimitedDropdownInput extends Component {
             value: null,
             choices: null
         };
-		this.loadChoices = this.loadChoices.bind(this);
-		this.loadChoices();
+        this.loadChoices = this.loadChoices.bind(this);
+        this.loadChoices();
         this.handleChange = this.handleChange.bind(this);
     }
 
@@ -23,7 +23,7 @@ class UnlimitedDropdownInput extends Component {
         try {
             const results = await getUntilDone(reference, filter || {});
             this.setState({ choices: results });
-        } catch(error) {
+        } catch (error) {
             console.error(error);
         }
     }
@@ -33,13 +33,13 @@ class UnlimitedDropdownInput extends Component {
     }
 
     render() {
-		const { source, label, optionText, optionValue } = this.props;
-		const selectProps = {
-			source: source,
-			choices: this.state.choices,
-			optionText: optionText,
-			optionValue: optionValue || 'id'
-		}
+        const { source, label, optionText, optionValue } = this.props;
+        const selectProps = {
+            source: source,
+            choices: this.state.choices,
+            optionText: optionText,
+            optionValue: optionValue || 'id'
+        };
         return (
             <span>
                 {this.state.choices ? (

--- a/admin/src/inputs/UnlimitedDropdownInput.js
+++ b/admin/src/inputs/UnlimitedDropdownInput.js
@@ -1,0 +1,68 @@
+import React, { Component } from 'react';
+import { Field } from 'redux-form';
+import PropTypes from 'prop-types';
+import { SelectInput } from 'admin-on-rest';
+import CircularProgress from 'material-ui/CircularProgress';
+
+import { getUntilDone } from '../utils';
+
+class UnlimitedDropdownInput extends Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            value: null,
+            choices: null
+        };
+		this.loadChoices = this.loadChoices.bind(this);
+		this.loadChoices();
+        this.handleChange = this.handleChange.bind(this);
+    }
+
+    async loadChoices() {
+        const { reference, filter } = this.props;
+        const results = await getUntilDone(reference, filter || {});
+        this.setState({ choices: results });
+    }
+
+    handleChange(value) {
+        this.setState({ value });
+    }
+
+    render() {
+		const { source, label, optionText, optionValue } = this.props;
+		const selectProps = {
+			source: source,
+			choices: this.state.choices,
+			optionText: optionText,
+			optionValue: optionValue || 'id'
+		}
+        return (
+            <span>
+                {this.state.choices ? (
+                    <Field
+                        name={source}
+                        component={SelectInput}
+                        props={selectProps}
+                        label={label || source}
+                        onChange={this.handleChange}
+                    />
+                ) : (
+                    <CircularProgress />
+                )}
+            </span>
+        );
+    }
+}
+UnlimitedDropdownInput.propTypes = {
+    source: PropTypes.string.isRequired,
+    reference: PropTypes.string.isRequired,
+    filter: PropTypes.object,
+    label: PropTypes.string,
+    optionText: PropTypes.string,
+    optionValue: PropTypes.string
+};
+UnlimitedDropdownInput.defaultProps = {
+    optionText: 'id'
+};
+
+export default UnlimitedDropdownInput;

--- a/admin/src/inputs/UnlimitedDropdownInput.js
+++ b/admin/src/inputs/UnlimitedDropdownInput.js
@@ -20,8 +20,12 @@ class UnlimitedDropdownInput extends Component {
 
     async loadChoices() {
         const { reference, filter } = this.props;
-        const results = await getUntilDone(reference, filter || {});
-        this.setState({ choices: results });
+        try {
+            const results = await getUntilDone(reference, filter || {});
+            this.setState({ choices: results });
+        } catch(error) {
+            console.error(error);
+        }
     }
 
     handleChange(value) {

--- a/swagger/management_layer.yml
+++ b/swagger/management_layer.yml
@@ -83,6 +83,9 @@ parameters:
     name: domain_id
     required: false
     type: integer
+    x-related-info:
+      rest_resource_name: domains
+      label: name
 
   optional_invitation_filter:
     description: An optional query parameter to filter by invitation_id
@@ -98,6 +101,9 @@ parameters:
     name: parent_id
     required: false
     type: integer
+    x-related-info:
+      rest_resource_name: domains
+      label: name
 
   optional_role_filter:
     description: An optional query parameter to filter by role_id
@@ -105,6 +111,9 @@ parameters:
     name: role_id
     required: false
     type: integer
+    x-related-info:
+      rest_resource_name: roles
+      label: label
 
   optional_user_filter:
     description: An optional query parameter to filter by user_id
@@ -171,6 +180,9 @@ parameters:
     name: site_id
     required: false
     type: integer
+    x-related-info:
+      rest_resource_name: sites
+      label: name
 
   admin_note_id:
     description: A unique integer value identifying the admin note.


### PR DESCRIPTION
**Background**: The domain_id, site_id and role_id filters for certain pages are just number inputs for the exact ID.

**What was Done:** These filters were given more detail in the specification and the filter regenerated as `ReferenceInput`s. However for domains and sites where the possibility of the API list return limit being met sometimes, a custom Component `UnlimitedDropdownInput` was created to use the previously implemented `getUntilDone` method in utils so the dropdown has all the selection data required.  