### PR TITLE
Feature/tech admin manage roles

### DIFF
--- a/admin/src/Menu.js
+++ b/admin/src/Menu.js
@@ -75,7 +75,7 @@ const Menu = ({ resources, onMenuTap, logout }) => (
                 leftIcon={<ManageIcon />}
             />
         ) : null}
-        {PermissionsStore.getPermissionFlags().contexts.length > 1 ? (
+        {Object.keys(PermissionsStore.getPermissionFlags().contexts).length > 1 ? (
             <MenuItemLink
                 to="/contextchanger"
                 primaryText="Context Changer"

--- a/admin/src/auth/PermissionsStore.js
+++ b/admin/src/auth/PermissionsStore.js
@@ -138,12 +138,12 @@ class PermissionsStore {
             {}
         );
         const currentContext = Object.keys(contexts)[0]
-        const splitName = currentContext.split(':');
+        const [contextType, contextID] = currentContext.split(':');
         const permissions = await restClient(
             OPERATIONAL,
-            splitName[0].indexOf('d') >= 0 ? 'user_domain_permissions' : 'user_site_permissions',
+            contextType === 'd' ? 'user_domain_permissions' : 'user_site_permissions',
             {
-                pathParameters: [userID, splitName[1]]
+                pathParameters: [userID, contextID]
             }
         );
         this.loadPermissions(permissions.data, contexts, currentContext);

--- a/admin/src/auth/PermissionsStore.js
+++ b/admin/src/auth/PermissionsStore.js
@@ -2,6 +2,8 @@
  * Generated authPermissions.js code. Edit at own risk.
  * When regenerated the changes will be lost.
  **/
+import restClient, { OPERATIONAL } from '../swaggerRestServer';
+
 class PermissionsStore {
     constructor() {
         if (!PermissionsStore.instance) {
@@ -113,12 +115,39 @@ class PermissionsStore {
                 }
             };
             this.permissionFlags = null;
+            this.getAndLoadPermissions = this.getAndLoadPermissions.bind(this);
             this.loadPermissions = this.loadPermissions.bind(this);
             this.getResourcePermission = this.getResourcePermission.bind(this);
             this.manyResourcePermissions = this.manyResourcePermissions.bind(this);
+            this.getPermissionFlags = this.getPermissionFlags.bind(this);
             PermissionsStore.instance = this;
         }
         return PermissionsStore.instance;
+    }
+    async getAndLoadPermissions(userID) {
+        const response = await restClient(OPERATIONAL, 'all_user_roles', {
+            pathParameters: [userID]
+        });
+        const contexts = Object.entries(response.data.roles_map).reduce(
+            (result, [key, value]) => {
+                if (value.length > 0) {
+                    result[key] = value;
+                }
+                return result;
+            },
+            {}
+        );
+        const currentContext = Object.keys(contexts)[0]
+        const splitName = currentContext.split(':');
+        const permissions = await restClient(
+            OPERATIONAL,
+            splitName[0].indexOf('d') >= 0 ? 'user_domain_permissions' : 'user_site_permissions',
+            {
+                pathParameters: [userID, splitName[1]]
+            }
+        );
+        this.loadPermissions(permissions.data, contexts, currentContext);
+        return Promise.resolve({ contexts, currentContext });
     }
     loadPermissions(userPermissions, contexts, currentContext) {
         this.permissionFlags = {};

--- a/admin/src/constants.js
+++ b/admin/src/constants.js
@@ -27,3 +27,5 @@ export const PERMISSIONS = {
         ['userdomainroles', 'remove']
     ]
 };
+
+export const SUPERADMIN = 'tech_admin';

--- a/admin/src/constants.js
+++ b/admin/src/constants.js
@@ -28,4 +28,4 @@ export const PERMISSIONS = {
     ]
 };
 
-export const SUPERADMIN = 'tech_admin';
+export const TECH_ADMIN = 'tech_admin';

--- a/admin/src/filters/DomainFilter.js
+++ b/admin/src/filters/DomainFilter.js
@@ -4,8 +4,6 @@
 **/
 import React from 'react';
 import {
-    SelectInput,
-    ReferenceInput,
     TextInput,
     Filter
 } from 'admin-on-rest';

--- a/admin/src/filters/UserSiteDataFilter.js
+++ b/admin/src/filters/UserSiteDataFilter.js
@@ -5,8 +5,6 @@
 import React from 'react';
 import {
     TextInput,
-    SelectInput,
-    ReferenceInput,
     Filter
 } from 'admin-on-rest';
 import UnlimitedDropdownInput from '../inputs/UnlimitedDropdownInput';

--- a/admin/src/pages/ContextChanger.js
+++ b/admin/src/pages/ContextChanger.js
@@ -59,7 +59,7 @@ class ContextChanger extends Component {
     }
 
     async getPlaces(placeName, domainsAndSites) {
-        const ids = domainsAndSites.reduce((array, place) => {
+        const ids = Object.keys(domainsAndSites).reduce((array, place) => {
             if (place.indexOf(placeName[0]) >= 0) {
                 array.push(parseInt(place.split(':')[1], 10));
             }
@@ -141,7 +141,7 @@ class ContextChanger extends Component {
                                     {domains && sites ? (
                                         <DropDownMenu value={value} onChange={this.handleChange}>
                                             {domainsAndSites &&
-                                                domainsAndSites.map(place => {
+                                                Object.keys(domainsAndSites).map(place => {
                                                     const splitPlace = place.split(':');
                                                     const text =
                                                         splitPlace[0].indexOf('d') >= 0

--- a/admin/src/pages/ContextChanger.js
+++ b/admin/src/pages/ContextChanger.js
@@ -87,16 +87,14 @@ class ContextChanger extends Component {
         if (this.state.value !== this.props.GMPContext) {
             const { value } = this.state;
             this.props.changeContext(value);
-            const splitName = value.split(':');
-            const user_id = jwtDecode(localStorage.getItem('id_token')).sub;
+            const [contextType, contextID] = value.split(':');
+            const userID = jwtDecode(localStorage.getItem('id_token')).sub;
             try {
                 const permissions = await restClient(
                     OPERATIONAL,
-                    splitName[0].indexOf('d') >= 0
-                        ? 'user_domain_permissions'
-                        : 'user_site_permissions',
+                    contextType === 'd' ? 'user_domain_permissions' : 'user_site_permissions',
                     {
-                        pathParameters: [user_id, splitName[1]]
+                        pathParameters: [userID, contextID]
                     }
                 );
                 PermissionsStore.loadPermissions(
@@ -142,16 +140,18 @@ class ContextChanger extends Component {
                                         <DropDownMenu value={value} onChange={this.handleChange}>
                                             {domainsAndSites &&
                                                 Object.keys(domainsAndSites).map(place => {
-                                                    const splitPlace = place.split(':');
+                                                    const [contextType, contextID] = place.split(
+                                                        ':'
+                                                    );
                                                     const text =
-                                                        splitPlace[0].indexOf('d') >= 0
+                                                        contextType === 'd'
                                                             ? domains
                                                                 ? domains[
-                                                                      parseInt(splitPlace[1], 10)
+                                                                      parseInt(contextID, 10)
                                                                   ].name
                                                                 : place
                                                             : sites
-                                                                ? sites[parseInt(splitPlace[1], 10)]
+                                                                ? sites[parseInt(contextID, 10)]
                                                                       .name
                                                                 : place;
                                                     return (
@@ -187,4 +187,7 @@ class ContextChanger extends Component {
     }
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(ContextChanger);
+export default connect(
+    mapStateToProps,
+    mapDispatchToProps
+)(ContextChanger);

--- a/admin/src/pages/ManageUserRoles/ManageUserRoles.js
+++ b/admin/src/pages/ManageUserRoles/ManageUserRoles.js
@@ -81,10 +81,10 @@ class ManageUserRoles extends Component {
     async getWhereUserHasRoles(contexts, roles) {
         const ids = Object.keys(contexts).reduce(
             (accumulator, place) => {
-                const splitPlace = place.split(':');
-                splitPlace[0] === 'd'
-                    ? accumulator.domains.push(splitPlace[1])
-                    : accumulator.sites.push(splitPlace[1]);
+                const [placeLetter, placeID] = place.split(':');
+                placeLetter === 'd'
+                    ? accumulator.domains.push(placeID)
+                    : accumulator.sites.push(placeID);
                 return accumulator;
             },
             { domains: [], sites: [] }
@@ -110,8 +110,8 @@ class ManageUserRoles extends Component {
                 if (hasTechAdmin) {
                     roleObjects = Object.values(roles);
                 }
-                const [place, placeID] = place.split(':');
-                place === 'd'
+                const [placeLetter, placeID] = place.split(':');
+                placeLetter === 'd'
                     ? (accumulator.domains[placeID] = roleObjects)
                     : (accumulator.sites[placeID] = roleObjects);
                 return accumulator;
@@ -280,7 +280,7 @@ class ManageUserRoles extends Component {
         Object.values(roleSelections).map(async roleSelection => {
             if (roleSelection.selected) {
                 try {
-                    await restClient(CREATE, `user${placeSplit[1]}roles`, {
+                    await restClient(CREATE, `user${place}roles`, {
                         data: {
                             user_id: userResults[selectedUser].id,
                             [`${place}_id`]: parseInt(placeID, 10),

--- a/admin/src/reducers/contextReducer.js
+++ b/admin/src/reducers/contextReducer.js
@@ -5,7 +5,7 @@ export default (state = {}, { type, payload }) => {
         case CONTEXT_DOMAINS_AND_SITES_ADD:
             return {
                 domainsAndSites: payload,
-                GMPContext: payload[0]
+                GMPContext: Object.keys(payload)[0]
             };
         case CONTEXT_CHANGE_GMP_CONTEXT:
             return {


### PR DESCRIPTION
**Background:** The roles displayed for user role assignment are only explicit roles and not effective roles. Also the SUPERADMIN known as `tech_admin` can currently only assign the tech_admin role on the domain/site where the `tech_admin` role is given to them explicitly.

**What Was Done:** The superadmin was added as a reference to `constants.js`. The Manage User Roles page now grabs the contexts and current context from the store and uses this to construct the choices for domain/site role assignment, since the contexts show the user's EFFECTIVE roles on all domains/sites. The roles are then inferred from the user's effective roles BUT if on a domain/site the user has the super admin role, then the user will be able to assign all the different roles, not just the ones they have on that domain or site.

PS. Also made a small clean up of the OIDC callback component and moved some calls around.