### PR TITLE
Feature/api context in calls

### DIFF
--- a/admin/src/Menu.js
+++ b/admin/src/Menu.js
@@ -52,17 +52,18 @@ const ICONS = {
 
 const Menu = ({ resources, onMenuTap, logout }) => (
     <div>
-        <span style={{lineHeight: '48px', fontWeight: 'bold', margin: '1rem'}}>
-            {`${PermissionsStore.getPermissionFlags().currentContext.obj
-                ? titleCase(
-                      PermissionsStore.getPermissionFlags().currentContext.obj.name.split('_').join(' ')
-                  )
-                : null}`}
-        </span>
         {Object.keys(PermissionsStore.getPermissionFlags().contexts).length > 1 ? (
             <MenuItemLink
                 to="/contextchanger"
-                primaryText="Context Changer"
+                primaryText={`Context: ${
+                    PermissionsStore.getPermissionFlags().currentContext.obj
+                        ? titleCase(
+                              PermissionsStore.getPermissionFlags()
+                                  .currentContext.obj.name.split('_')
+                                  .join(' ')
+                          )
+                        : 'Error: Not loaded yet! Something is wrong.'
+                }`}
                 onClick={onMenuTap}
                 leftIcon={<ContextSwitchIcon color={pink300} />}
             />

--- a/admin/src/Menu.js
+++ b/admin/src/Menu.js
@@ -24,7 +24,7 @@ import ContextSwitchIcon from 'material-ui/svg-icons/communication/swap-calls';
 import { pink300 } from 'material-ui/styles/colors';
 
 import PermissionsStore from './auth/PermissionsStore';
-import { titleCase } from './utils';
+import { titleCase, NotEmptyObject } from './utils';
 import { TITLES, PERMISSIONS } from './constants';
 
 const ICONS = {
@@ -52,7 +52,7 @@ const ICONS = {
 
 const Menu = ({ resources, onMenuTap, logout }) => (
     <div>
-        {Object.keys(PermissionsStore.getAllContexts()).length > 1 ? (
+        {NotEmptyObject(PermissionsStore.getAllContexts()) ? (
             <MenuItemLink
                 to="/contextchanger"
                 primaryText={`Context: ${titleCase(

--- a/admin/src/Menu.js
+++ b/admin/src/Menu.js
@@ -52,10 +52,12 @@ const ICONS = {
 
 const Menu = ({ resources, onMenuTap, logout }) => (
     <div>
-        <span>
-            {PermissionsStore.getPermissionFlags().currentContext.obj
-                ? PermissionsStore.getPermissionFlags().currentContext.obj.name
-                : null}
+        <span style={{lineHeight: '48px', fontWeight: 'bold', margin: '1rem'}}>
+            {`${PermissionsStore.getPermissionFlags().currentContext.obj
+                ? titleCase(
+                      PermissionsStore.getPermissionFlags().currentContext.obj.name.split('_').join(' ')
+                  )
+                : null}`}
         </span>
         {Object.keys(PermissionsStore.getPermissionFlags().contexts).length > 1 ? (
             <MenuItemLink

--- a/admin/src/Menu.js
+++ b/admin/src/Menu.js
@@ -52,7 +52,11 @@ const ICONS = {
 
 const Menu = ({ resources, onMenuTap, logout }) => (
     <div>
-        <span>{PermissionsStore.getPermissionFlags().currentContext}</span>
+        <span>
+            {PermissionsStore.getPermissionFlags().currentContext.obj
+                ? PermissionsStore.getPermissionFlags().currentContext.obj.name
+                : null}
+        </span>
         {Object.keys(PermissionsStore.getPermissionFlags().contexts).length > 1 ? (
             <MenuItemLink
                 to="/contextchanger"

--- a/admin/src/Menu.js
+++ b/admin/src/Menu.js
@@ -52,6 +52,15 @@ const ICONS = {
 
 const Menu = ({ resources, onMenuTap, logout }) => (
     <div>
+        <span>{PermissionsStore.getPermissionFlags().currentContext}</span>
+        {Object.keys(PermissionsStore.getPermissionFlags().contexts).length > 1 ? (
+            <MenuItemLink
+                to="/contextchanger"
+                primaryText="Context Changer"
+                onClick={onMenuTap}
+                leftIcon={<ContextSwitchIcon color={pink300} />}
+            />
+        ) : null}
         {resources
             ? resources.map(resource => (
                   <MenuItemLink
@@ -73,14 +82,6 @@ const Menu = ({ resources, onMenuTap, logout }) => (
                 primaryText="Manage User Roles"
                 onClick={onMenuTap}
                 leftIcon={<ManageIcon />}
-            />
-        ) : null}
-        {Object.keys(PermissionsStore.getPermissionFlags().contexts).length > 1 ? (
-            <MenuItemLink
-                to="/contextchanger"
-                primaryText="Context Changer"
-                onClick={onMenuTap}
-                leftIcon={<ContextSwitchIcon color={pink300} />}
             />
         ) : null}
         {logout}

--- a/admin/src/Menu.js
+++ b/admin/src/Menu.js
@@ -52,18 +52,14 @@ const ICONS = {
 
 const Menu = ({ resources, onMenuTap, logout }) => (
     <div>
-        {Object.keys(PermissionsStore.getPermissionFlags().contexts).length > 1 ? (
+        {Object.keys(PermissionsStore.getAllContexts()).length > 1 ? (
             <MenuItemLink
                 to="/contextchanger"
-                primaryText={`Context: ${
-                    PermissionsStore.getPermissionFlags().currentContext.obj
-                        ? titleCase(
-                              PermissionsStore.getPermissionFlags()
-                                  .currentContext.obj.name.split('_')
-                                  .join(' ')
-                          )
-                        : 'Error: Not loaded yet! Something is wrong.'
-                }`}
+                primaryText={`Context: ${titleCase(
+                    PermissionsStore.getCurrentContext()
+                        .obj.name.split('_')
+                        .join(' ')
+                )}`}
                 onClick={onMenuTap}
                 leftIcon={<ContextSwitchIcon color={pink300} />}
             />

--- a/admin/src/auth/PermissionsStore.js
+++ b/admin/src/auth/PermissionsStore.js
@@ -2,7 +2,7 @@
  * Generated authPermissions.js code. Edit at own risk.
  * When regenerated the changes will be lost.
  **/
-import restClient, { OPERATIONAL } from '../swaggerRestServer';
+import restClient, { OPERATIONAL, GET_ONE } from '../swaggerRestServer';
 
 class PermissionsStore {
     constructor() {
@@ -128,17 +128,24 @@ class PermissionsStore {
         const response = await restClient(OPERATIONAL, 'all_user_roles', {
             pathParameters: [userID]
         });
-        const contexts = Object.entries(response.data.roles_map).reduce(
-            (result, [key, value]) => {
-                if (value.length > 0) {
-                    result[key] = value;
-                }
-                return result;
-            },
-            {}
-        );
-        const currentContext = Object.keys(contexts)[0]
+        const contexts = Object.entries(response.data.roles_map).reduce((result, [key, value]) => {
+            if (value.length > 0) {
+                result[key] = value;
+            }
+            return result;
+        }, {});
+        let currentContext = Object.keys(contexts)[0];
         const [contextType, contextID] = currentContext.split(':');
+        const currentContextObject = await restClient(
+            GET_ONE,
+            contextType === 'd' ? 'domains' : 'sites',
+            { id: contextID }
+        );
+        currentContext = {
+            key: currentContext,
+            obj: currentContextObject.data
+        } 
+
         const permissions = await restClient(
             OPERATIONAL,
             contextType === 'd' ? 'user_domain_permissions' : 'user_site_permissions',

--- a/admin/src/auth/PermissionsStore.js
+++ b/admin/src/auth/PermissionsStore.js
@@ -212,6 +212,12 @@ class PermissionsStore {
         }
         return this.permissionFlags;
     }
+    getAllContexts() {
+        return this.getPermissionFlags().contexts;
+    }
+    getCurrentContext() {
+        return this.getPermissionFlags().currentContext;
+    }
 }
 
 const storeInstance = new PermissionsStore();

--- a/admin/src/auth/authClient.js
+++ b/admin/src/auth/authClient.js
@@ -7,7 +7,7 @@ export default (type, params) => {
             const logoutQueryString = GenerateQueryString({
                 id_token_hint: localStorage.getItem('id_token'),
                 post_logout_redirect_uri: process.env.REACT_APP_PORTAL_URL
-            })
+            });
             localStorage.removeItem('id_token');
             localStorage.removeItem('auth_state');
             localStorage.removeItem('permissions');
@@ -23,7 +23,9 @@ export default (type, params) => {
         return Promise.resolve();
     }
     if (type === AUTH_CHECK) {
-        return localStorage.getItem('id_token') ? Promise.resolve() : Promise.reject();
+        return localStorage.getItem('id_token') && localStorage.getItem('permissions')
+            ? Promise.resolve()
+            : Promise.reject();
     }
     return Promise.resolve();
-}
+};

--- a/admin/src/pages/ContextChanger.js
+++ b/admin/src/pages/ContextChanger.js
@@ -37,24 +37,29 @@ const mapDispatchToProps = dispatch => {
 class ContextChanger extends Component {
     constructor(props) {
         super(props);
-        const permissions = PermissionsStore.getPermissionFlags();
+        let currentContext = null,
+            contexts = null;
+
+        if (this.props.GMPContext) {
+            currentContext = this.props.GMPContext;
+            contexts = this.props.domainsAndSites
+        } else {
+            currentContext = PermissionsStore.getCurrentContext();
+            contexts = PermissionsStore.getAllContexts();
+            this.props.domainsAndSitesAdd(contexts);
+            this.props.changeContext(currentContext);
+        }
         this.state = {
             changing: false,
-            value:
-                (this.props.GMPContext && this.props.GMPContext.key) ||
-                permissions.currentContext.key,
+            value: currentContext.key,
             redirect: false,
             validToken: true,
             domains: null,
             sites: null
         };
-        if (!this.props.GMPContext) {
-            this.props.domainsAndSitesAdd(permissions.contexts);
-            this.props.changeContext(permissions.currentContext);
-        }
         this.getPlaces = this.getPlaces.bind(this);
-        this.getPlaces('domain', this.props.domainsAndSites || permissions.contexts);
-        this.getPlaces('site', this.props.domainsAndSites || permissions.contexts);
+        this.getPlaces('domain', contexts);
+        this.getPlaces('site', contexts);
         this.handleChange = this.handleChange.bind(this);
         this.handleSelection = this.handleSelection.bind(this);
         this.handleAPIError = this.handleAPIError.bind(this);

--- a/admin/src/pages/ManageUserRoles/AssignRoleCard.js
+++ b/admin/src/pages/ManageUserRoles/AssignRoleCard.js
@@ -8,6 +8,8 @@ import Divider from 'material-ui/Divider';
 import DropDownMenu from 'material-ui/DropDownMenu';
 import RaisedButton from 'material-ui/RaisedButton';
 import MenuItem from 'material-ui/MenuItem/MenuItem';
+
+import { NotEmptyObject } from '../../utils';
 import { styles } from '../../Theme';
 
 const AssignRoleCard = props => {
@@ -33,7 +35,7 @@ const AssignRoleCard = props => {
                     autoWidth={false}
                 >
                     <MenuItem value={null} primaryText="Select Domain/Site" disabled />
-                    {Object.keys(userdomains).length > 0
+                    {NotEmptyObject(userdomains)
                         ? Object.values(userdomains).map(domain => (
                               <MenuItem
                                   key={`${domain.id}:domain`}
@@ -43,10 +45,10 @@ const AssignRoleCard = props => {
                               />
                           ))
                         : null}
-                    {Object.keys(userdomains).length > 0 && Object.keys(usersites).length > 0 ? (
+                    {NotEmptyObject(userdomains) && NotEmptyObject(usersites) ? (
                         <Divider />
                     ) : null}
-                    {Object.keys(usersites).length > 0
+                    {NotEmptyObject(usersites)
                         ? Object.values(usersites).map(site => (
                               <MenuItem
                                   key={`${site.id}:site`}
@@ -61,7 +63,7 @@ const AssignRoleCard = props => {
                     <div>
                         <CardHeader subtitle="Please choose the roles to add:" />
                         <CardText>
-                            {Object.keys(roleSelections).length > 0
+                            {NotEmptyObject(roleSelections)
                                 ? Object.values(roleSelections).map(roleSelection => (
                                       <Checkbox
                                           key={roleSelection.id}

--- a/admin/src/pages/ManageUserRoles/ManageUserRoles.js
+++ b/admin/src/pages/ManageUserRoles/ManageUserRoles.js
@@ -32,10 +32,9 @@ const mapDispatchToProps = dispatch => ({
 class ManageUserRoles extends Component {
     constructor(props) {
         super(props);
-        const permissions = PermissionsStore.getPermissionFlags();
         if (!this.props.GMPContext) {
-            this.props.domainsAndSitesAdd(permissions.contexts);
-            this.props.changeContext(permissions.currentContext);
+            this.props.domainsAndSitesAdd(PermissionsStore.getAllContexts());
+            this.props.changeContext(PermissionsStore.getCurrentContext());
         }
         this.state = {
             managerRoles: null,
@@ -54,7 +53,7 @@ class ManageUserRoles extends Component {
             validToken: true
         };
         this.getAllUserData = this.getAllUserData.bind(this);
-        this.getAllUserData(this.props.domainsAndSites || permissions.contexts);
+        this.getAllUserData(this.props.domainsAndSites || PermissionsStore.getAllContexts());
         this.getWhereUserHasRoles = this.getWhereUserHasRoles.bind(this);
         this.handleSearch = this.handleSearch.bind(this);
         this.handleSelect = this.handleSelect.bind(this);

--- a/admin/src/pages/ManageUserRoles/UserCard.js
+++ b/admin/src/pages/ManageUserRoles/UserCard.js
@@ -7,6 +7,7 @@ import CardTitle from 'material-ui/Card/CardTitle';
 import Chip from 'material-ui/Chip';
 import Divider from 'material-ui/Divider';
 import { styles } from '../../Theme';
+import { NotEmptyObject } from '../../utils';
 
 const UserCard = props => {
     const { user, userRoles, handleDelete } = props;
@@ -16,7 +17,7 @@ const UserCard = props => {
             <Divider />
             <CardHeader title="Domain Roles" />
             <CardText style={styles.wrapper}>
-                {userRoles && userRoles.domainRoles && Object.keys(userRoles.domainRoles).length > 0
+                {userRoles && userRoles.domainRoles && NotEmptyObject(userRoles.domainRoles)
                     ? Object.values(userRoles.domainRoles).map((domainRole, index) => (
                           <Chip
                               key={index}
@@ -37,7 +38,7 @@ const UserCard = props => {
             <Divider />
             <CardHeader title="Site Roles" />
             <CardText style={styles.wrapper}>
-                {userRoles && userRoles.siteRoles && Object.keys(userRoles.siteRoles).length > 0
+                {userRoles && userRoles.siteRoles && NotEmptyObject(userRoles.siteRoles)
                     ? Object.values(userRoles.siteRoles).map((siteRole, index) => (
                           <Chip
                               key={index}

--- a/admin/src/pages/WaitingPage.js
+++ b/admin/src/pages/WaitingPage.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { pink500 } from 'material-ui/styles/colors';
+import WaitIcon from 'material-ui/svg-icons/action/update';
+import LinearProgress from 'material-ui/LinearProgress';
+import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
+
+import { muiTheme, styles } from '../Theme';
+
+const WaitingPage = () => (
+    <MuiThemeProvider muiTheme={muiTheme}>
+        <div style={{ ...styles.main, backgroundColor: pink500 }}>
+            <WaitIcon style={styles.waitIcon} />
+            <LinearProgress mode="indeterminate" style={styles.linearProgress} />
+        </div>
+    </MuiThemeProvider>
+);
+
+export default WaitingPage;

--- a/admin/src/reducers/contextReducer.js
+++ b/admin/src/reducers/contextReducer.js
@@ -5,7 +5,7 @@ export default (state = {}, { type, payload }) => {
         case CONTEXT_DOMAINS_AND_SITES_ADD:
             return {
                 domainsAndSites: payload,
-                GMPContext: Object.keys(payload)[0]
+                GMPContext: {}
             };
         case CONTEXT_CHANGE_GMP_CONTEXT:
             return {

--- a/admin/src/swaggerRestServer.js
+++ b/admin/src/swaggerRestServer.js
@@ -258,7 +258,9 @@ const httpClient = (url, options = {}) => {
         options.headers = new Headers({ Accept: 'application/json' });
     }
     const id_token = localStorage.getItem('id_token');
+    const permissions = JSON.parse(localStorage.getItem('permissions'));
     options.headers.set('Authorization', `Bearer ${id_token}`);
+    options.headers.set('X-GE-Portal-Context', permissions ? permissions.currentContext.key : null);
     return fetchUtils.fetchJson(url, options);
 };
 

--- a/admin/src/swaggerRestServer.js
+++ b/admin/src/swaggerRestServer.js
@@ -260,7 +260,9 @@ const httpClient = (url, options = {}) => {
     const id_token = localStorage.getItem('id_token');
     const permissions = JSON.parse(localStorage.getItem('permissions'));
     options.headers.set('Authorization', `Bearer ${id_token}`);
-    options.headers.set('X-GE-Portal-Context', permissions ? permissions.currentContext.key : null);
+    if (permissions) {
+        options.headers.set('X-GE-Portal-Context', permissions.currentContext.key);
+    }
     return fetchUtils.fetchJson(url, options);
 };
 

--- a/admin/src/utils.js
+++ b/admin/src/utils.js
@@ -45,6 +45,8 @@ export const getUniqueIDs = (list, key) => {
     }, []);
 };
 
+export const NotEmptyObject = obj => Object.keys(obj).length > 0;
+
 export const GenerateQueryString = parameters => {
     return Object.entries(parameters)
         .map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`)
@@ -76,7 +78,7 @@ export const base64urlDecode = str => {
 };
 
 const base64urlUnescape = str => {
-    str += Array(5 - str.length % 4).join('=');
+    str += Array(5 - (str.length % 4)).join('=');
     return str.replace(/-/g, '+').replace(/_/g, '/');
 };
 /** End of Generated Code **/


### PR DESCRIPTION
**Background:** The management layer calls will change their results based on the context given in the header and the current context is not shown anywhere on the admin on rest page.

**What was done:** The management portal was updated in the HTTP client to grab the current context from localStorage (as I do not have access to the redux store unless I am in a component within the `Admin` parent component.). I attach the current context to the header of each call as per CobusC specification of the management layer. The current context was also attached to the MenuItem for changing the context in the Admin Menu Side Bar. 

PS. Some minor refactoring of the PermissionsStore and its usage in the code.