### PR TITLE
Feature/implied user filters

### DIFF
--- a/admin/src/actions/context.js
+++ b/admin/src/actions/context.js
@@ -18,11 +18,7 @@ export const contextChangeSiteIDs = siteIDs => ({
     payload: siteIDs
 });
 
-export const contextChangeAll = ({ domainsAndSites, GMPContext, siteIDs }) => ({
+export const contextChangeAll = newContextState => ({
     type: CONTEXT_CHANGE_ALL,
-    payload: {
-        domainsAndSites,
-        GMPContext,
-        siteIDs
-    }
+    payload: newContextState
 });

--- a/admin/src/actions/context.js
+++ b/admin/src/actions/context.js
@@ -1,12 +1,28 @@
 export const CONTEXT_DOMAINS_AND_SITES_ADD = 'CONTEXT_DOMAINS_AND_SITES_ADD';
 export const CONTEXT_CHANGE_GMP_CONTEXT = 'CONTEXT_CHANGE_GMP_CONTEXT';
+export const CONTEXT_CHANGE_SITE_IDS = 'CONTEXT_CHANGE_SITE_IDS';
+export const CONTEXT_CHANGE_ALL = 'CONTEXT_CHANGE_ALL';
 
-export const contextDomainsAndSitesAdd = allPlaces => ({
+export const contextDomainsAndSitesAdd = domainsAndSites => ({
     type: CONTEXT_DOMAINS_AND_SITES_ADD,
-    payload: allPlaces
+    payload: domainsAndSites
 });
 
-export const contextChangeGMPContext = newContext => ({
-	type: CONTEXT_CHANGE_GMP_CONTEXT,
-	payload: newContext
+export const contextChangeGMPContext = GMPContext => ({
+    type: CONTEXT_CHANGE_GMP_CONTEXT,
+    payload: GMPContext
+});
+
+export const contextChangeSiteIDs = siteIDs => ({
+    type: CONTEXT_CHANGE_SITE_IDS,
+    payload: siteIDs
+});
+
+export const contextChangeAll = ({ domainsAndSites, GMPContext, siteIDs }) => ({
+    type: CONTEXT_CHANGE_ALL,
+    payload: {
+        domainsAndSites,
+        GMPContext,
+        siteIDs
+    }
 });

--- a/admin/src/auth/OIDCCallback.js
+++ b/admin/src/auth/OIDCCallback.js
@@ -6,12 +6,11 @@ import { Redirect } from 'react-router';
 
 import PermissionsStore from '../auth/PermissionsStore';
 import { base64urlDecode } from '../utils';
-import { contextDomainsAndSitesAdd, contextChangeGMPContext } from '../actions/context';
+import { contextChangeAll } from '../actions/context';
 import WaitingPage from '../pages/WaitingPage';
 
 const mapDispatchToProps = dispatch => ({
-    domainsAndSitesAdd: domainsAndSites => dispatch(contextDomainsAndSitesAdd(domainsAndSites)),
-    changeContext: newContext => dispatch(contextChangeGMPContext(newContext))
+    contextChangeAll: payload => dispatch(contextChangeAll(payload))
 });
 
 class OIDCCallback extends Component {
@@ -60,11 +59,16 @@ class OIDCCallback extends Component {
             localStorage.setItem('id_token', parsedQuery.id_token);
             const userID = jwtDecode(parsedQuery.id_token).sub;
             try {
-                const { contexts, currentContext } = await PermissionsStore.getAndLoadPermissions(
-                    userID
-                );
-                this.props.domainsAndSitesAdd(contexts);
-                this.props.changeContext(currentContext);
+                const {
+                    contexts,
+                    currentContext,
+                    siteIDs
+                } = await PermissionsStore.getAndLoadPermissions(userID);
+                this.props.contextChangeAll({
+                    domainsAndSites: contexts,
+                    GMPContext: currentContext,
+                    siteIDs
+                });
                 this.setState({ loginComplete: true });
             } catch (error) {
                 console.error(error);

--- a/admin/src/auth/PermissionsStore.js
+++ b/admin/src/auth/PermissionsStore.js
@@ -3,7 +3,7 @@
  * When regenerated the changes will be lost.
  **/
 import restClient, { OPERATIONAL, GET_ONE } from '../swaggerRestServer';
-import { NotEmptyObject } from '../utils';
+import { NotEmptyObject, getSitesForContext } from '../utils';
 
 class PermissionsStore {
     constructor() {
@@ -155,12 +155,13 @@ class PermissionsStore {
                     pathParameters: [userID, contextID]
                 }
             );
-            this.loadPermissions(permissions.data, contexts, currentContext);
-            return Promise.resolve({ contexts, currentContext });
+            const siteIDs = await getSitesForContext(currentContext);
+            this.loadPermissions(permissions.data, contexts, currentContext, siteIDs);
+            return Promise.resolve({ contexts, currentContext, siteIDs });
         }
         return Promise.resolve({ contexts: {}, currentContext: {} });
     }
-    loadPermissions(userPermissions, contexts, currentContext) {
+    loadPermissions(userPermissions, contexts, currentContext, siteIDs) {
         this.permissionFlags = {};
         const allowAccess = (userPermissions, requiredPermissions) => {
             if (requiredPermissions.length > 0) {
@@ -185,7 +186,8 @@ class PermissionsStore {
         this.permissionFlags = {
             ...this.permissionFlags,
             contexts,
-            currentContext
+            currentContext,
+            siteIDs
         };
         localStorage.setItem('permissions', JSON.stringify(this.permissionFlags));
     }
@@ -223,6 +225,10 @@ class PermissionsStore {
     getCurrentContext() {
         const permissions = this.getPermissionFlags();
         return permissions ? this.getPermissionFlags().currentContext : {};
+    }
+    getSiteIDs() {
+        const permissions = this.getPermissionFlags();
+        return permissions ? this.getPermissionFlags().siteIDs : '';
     }
 }
 

--- a/admin/src/constants.js
+++ b/admin/src/constants.js
@@ -6,6 +6,7 @@ export const TITLES = {
     siteroles: 'Site Roles',
     userdomainroles: 'User Domain Roles',
     usersiteroles: 'User Site Roles',
+    usersitedata: 'User Site Data',
     adminnotes: 'Admin Notes',
     sitedataschemas: 'Site Data Schemas',
     organisationalunits: 'Organisations'

--- a/admin/src/filters/UserFilter.js
+++ b/admin/src/filters/UserFilter.js
@@ -15,6 +15,7 @@ import {
 import PermissionsStore from '../auth/PermissionsStore';
 import DateRangeInput from '../inputs/DateRangeInput';
 import UnlimitedDropdownInput from '../inputs/UnlimitedDropdownInput';
+import { moreThanOneID } from '../utils';
 
 const parseUserIds = value => value.replace(/[^\w]/gi, ',');
 
@@ -42,7 +43,7 @@ const UserFilter = props => (
         <BooleanInput label="Two factor Auth Enabled" source="tfa_enabled" />
         <BooleanInput label="Has Organisational Unit" source="has_organisational_unit" />
         <TextInput label="User Ids" source="user_ids" parse={parseUserIds} />
-        {PermissionsStore.getSiteIDs().length > 1 ? (
+        {moreThanOneID(PermissionsStore.getSiteIDs()) ? (
             <UnlimitedDropdownInput
                 label="Site"
                 source="site_ids"

--- a/admin/src/filters/UserFilter.js
+++ b/admin/src/filters/UserFilter.js
@@ -1,7 +1,7 @@
-/** 
+/**
  * Generated Filters.js code. Edit at own risk.
  * When regenerated the changes will be lost.
-**/
+ **/
 import React from 'react';
 import {
     SelectInput,
@@ -11,6 +11,8 @@ import {
     NumberInput,
     Filter
 } from 'admin-on-rest';
+
+import PermissionsStore from '../auth/PermissionsStore';
 import DateRangeInput from '../inputs/DateRangeInput';
 import UnlimitedDropdownInput from '../inputs/UnlimitedDropdownInput';
 
@@ -18,7 +20,7 @@ const parseUserIds = value => value.replace(/[^\w]/gi, ',');
 
 const UserFilter = props => (
     <Filter {...props}>
-	<TextInput label="Search" source="q" alwaysOn />
+        <TextInput label="Search" source="q" alwaysOn />
         <DateRangeInput label="Birth Date" source="birth_date" />
         <ReferenceInput label="Country" source="country" reference="countries" allowEmpty>
             <SelectInput optionText="code" />
@@ -40,7 +42,15 @@ const UserFilter = props => (
         <BooleanInput label="Two factor Auth Enabled" source="tfa_enabled" />
         <BooleanInput label="Has Organisational Unit" source="has_organisational_unit" />
         <TextInput label="User Ids" source="user_ids" parse={parseUserIds} />
-        <UnlimitedDropdownInput label="Site" source="site_ids" reference="sites" optionText="name" />
+        {PermissionsStore.getSiteIDs().length > 1 ? (
+            <UnlimitedDropdownInput
+                label="Site"
+                source="site_ids"
+                reference="sites"
+                optionText="name"
+                filter={{ site_ids: PermissionsStore.getSiteIDs() }}
+            />
+        ) : null}
     </Filter>
 );
 

--- a/admin/src/inputs/UnlimitedDropdownInput.js
+++ b/admin/src/inputs/UnlimitedDropdownInput.js
@@ -5,6 +5,7 @@ import { SelectInput } from 'admin-on-rest';
 import CircularProgress from 'material-ui/CircularProgress';
 
 import { getUntilDone } from '../utils';
+import restClient, { GET_LIST } from '../swaggerRestServer';
 
 class UnlimitedDropdownInput extends Component {
     constructor(props) {
@@ -19,9 +20,11 @@ class UnlimitedDropdownInput extends Component {
     }
 
     async loadChoices() {
-        const { reference, filter } = this.props;
+        const { reference, filter, limited } = this.props;
         try {
-            const results = await getUntilDone(reference, filter || {});
+            const results = limited
+                ? await restClient(GET_LIST, reference, { filter })
+                : await getUntilDone(reference, filter);
             this.setState({ choices: results });
         } catch (error) {
             console.error(error);
@@ -63,10 +66,13 @@ UnlimitedDropdownInput.propTypes = {
     filter: PropTypes.object,
     label: PropTypes.string,
     optionText: PropTypes.string,
-    optionValue: PropTypes.string
+    optionValue: PropTypes.string,
+    limited: PropTypes.bool
 };
 UnlimitedDropdownInput.defaultProps = {
-    optionText: 'id'
+    optionText: 'id',
+    limited: false,
+    filter: {}
 };
 
 export default UnlimitedDropdownInput;

--- a/admin/src/pages/ManageUserRoles/ManageUserRoles.js
+++ b/admin/src/pages/ManageUserRoles/ManageUserRoles.js
@@ -32,7 +32,7 @@ const mapStateToProps = state => {
     return {
         domainsAndSites,
         GMPContext
-    }
+    };
 };
 
 const mapDispatchToProps = dispatch => ({
@@ -135,7 +135,7 @@ class ManageUserRoles extends Component {
         });
         if (input.length > 2) {
             restClient(GET_LIST, 'users', {
-                filter: { q: input, tfa_enabled: true, has_organisational_unit: true }
+                filter: { q: input, tfa_enabled: true, has_organisational_unit: true, site_ids: '' }
             })
                 .then(response => {
                     const userResults = response.data.map(obj => ({

--- a/admin/src/pages/ManageUserRoles/ManageUserRoles.js
+++ b/admin/src/pages/ManageUserRoles/ManageUserRoles.js
@@ -19,9 +19,21 @@ import PermissionsStore from '../../auth/PermissionsStore';
 import CircularProgress from 'material-ui/CircularProgress/CircularProgress';
 import { TECH_ADMIN } from '../../constants';
 
-const mapStateToProps = state => ({
-    domainsAndSites: state.context.domainsAndSites
-});
+const mapStateToProps = state => {
+    let GMPContext = {},
+        domainsAndSites = {};
+    if (state.context.GMPContext) {
+        GMPContext = state.context.GMPContext;
+        domainsAndSites = state.context.domainsAndSites;
+    } else {
+        GMPContext = PermissionsStore.getCurrentContext();
+        domainsAndSites = PermissionsStore.getAllContexts();
+    }
+    return {
+        domainsAndSites,
+        GMPContext
+    }
+};
 
 const mapDispatchToProps = dispatch => ({
     domainsAndSitesAdd: domainsAndSites => dispatch(contextDomainsAndSitesAdd(domainsAndSites)),
@@ -32,10 +44,6 @@ const mapDispatchToProps = dispatch => ({
 class ManageUserRoles extends Component {
     constructor(props) {
         super(props);
-        if (!this.props.GMPContext) {
-            this.props.domainsAndSitesAdd(PermissionsStore.getAllContexts());
-            this.props.changeContext(PermissionsStore.getCurrentContext());
-        }
         this.state = {
             managerRoles: null,
             search: '',
@@ -53,7 +61,7 @@ class ManageUserRoles extends Component {
             validToken: true
         };
         this.getAllUserData = this.getAllUserData.bind(this);
-        this.getAllUserData(this.props.domainsAndSites || PermissionsStore.getAllContexts());
+        this.getAllUserData(this.props.domainsAndSites);
         this.getWhereUserHasRoles = this.getWhereUserHasRoles.bind(this);
         this.handleSearch = this.handleSearch.bind(this);
         this.handleSelect = this.handleSelect.bind(this);

--- a/admin/src/reducers/contextReducer.js
+++ b/admin/src/reducers/contextReducer.js
@@ -1,16 +1,33 @@
-import { CONTEXT_DOMAINS_AND_SITES_ADD, CONTEXT_CHANGE_GMP_CONTEXT } from '../actions/context';
+import {
+    CONTEXT_DOMAINS_AND_SITES_ADD,
+    CONTEXT_CHANGE_GMP_CONTEXT,
+    CONTEXT_CHANGE_SITE_IDS,
+    CONTEXT_CHANGE_ALL
+} from '../actions/context';
 
 export default (state = {}, { type, payload }) => {
     switch (type) {
         case CONTEXT_DOMAINS_AND_SITES_ADD:
             return {
                 domainsAndSites: payload,
-                GMPContext: {}
+                GMPContext: {},
+                siteIDs: ''
             };
         case CONTEXT_CHANGE_GMP_CONTEXT:
             return {
                 domainsAndSites: state.domainsAndSites,
-                GMPContext: payload
+                GMPContext: payload,
+                siteIDs: ''
+            };
+        case CONTEXT_CHANGE_SITE_IDS:
+            return {
+                domainsAndSites: state.domainsAndSites,
+                GMPContext: state.GMPContext,
+                siteIDs: payload
+            };
+        case CONTEXT_CHANGE_ALL:
+            return {
+                ...payload
             };
         default:
             return state;

--- a/admin/src/resources/User.js
+++ b/admin/src/resources/User.js
@@ -25,6 +25,7 @@ import {
     EditButton,
     ShowButton
 } from 'admin-on-rest';
+
 import FieldSelectDatagrid from '../grids/FieldSelectDatagrid';
 import PermissionsStore from '../auth/PermissionsStore';
 import EmptyField from '../fields/EmptyField';
@@ -39,7 +40,7 @@ const validationEditUser = values => {
 const hiddenFields = ['created_at', 'updated_at', 'avatar', 'country_code'];
 
 export const UserList = props => (
-    <List {...props} title="User List" filters={<UserFilter />}>
+    <List {...props} title="User List" filters={<UserFilter />} filter={{ site_ids: PermissionsStore.getSiteIDs() }} >
         <FieldSelectDatagrid defaultHiddenFields={hiddenFields} bodyOptions={ { showRowHover: true } }>
             <TextField source="id" />
             <TextField source="username" />

--- a/admin/src/resources/User.js
+++ b/admin/src/resources/User.js
@@ -40,7 +40,7 @@ const validationEditUser = values => {
 const hiddenFields = ['created_at', 'updated_at', 'avatar', 'country_code'];
 
 export const UserList = props => (
-    <List {...props} title="User List" filters={<UserFilter />} filter={{ site_ids: PermissionsStore.getSiteIDs() }} >
+    <List {...props} title="User List" filters={<UserFilter />} >
         <FieldSelectDatagrid defaultHiddenFields={hiddenFields} bodyOptions={ { showRowHover: true } }>
             <TextField source="id" />
             <TextField source="username" />

--- a/admin/src/resources/UserDomainRole.js
+++ b/admin/src/resources/UserDomainRole.js
@@ -22,6 +22,7 @@ import {
 import PermissionsStore from '../auth/PermissionsStore';
 import EmptyField from '../fields/EmptyField';
 import UserDomainRoleFilter from '../filters/UserDomainRoleFilter';
+import UnlimitedDropdownInput from '../inputs/UnlimitedDropdownInput';
 
 const validationCreateUserDomainRole = values => {
     const errors = {};
@@ -72,9 +73,13 @@ export const UserDomainRoleList = props => (
 export const UserDomainRoleCreate = props => (
     <Create {...props} title="UserDomainRole Create">
         <SimpleForm validate={validationCreateUserDomainRole}>
-            <ReferenceInput label="User" source="user_id" reference="users" perPage={0} allowEmpty>
-                <SelectInput optionText="username" />
-            </ReferenceInput>
+            <UnlimitedDropdownInput
+                label="User"
+                source="user_id"
+                reference="users"
+                optionText="username"
+                filter={{ site_ids: '' }}
+            />
             <ReferenceInput label="Domain" source="domain_id" reference="domains" perPage={0} allowEmpty>
                 <SelectInput optionText="name" />
             </ReferenceInput>

--- a/admin/src/resources/UserSiteData.js
+++ b/admin/src/resources/UserSiteData.js
@@ -26,6 +26,7 @@ import PermissionsStore from '../auth/PermissionsStore';
 import EmptyField from '../fields/EmptyField';
 import ObjectField from '../fields/ObjectField';
 import UserSiteDataFilter from '../filters/UserSiteDataFilter';
+import UnlimitedDropdownInput from '../inputs/UnlimitedDropdownInput';
 
 const validationCreateUserSiteData = values => {
     const errors = {};
@@ -76,9 +77,13 @@ export const UserSiteDataList = props => (
 export const UserSiteDataCreate = props => (
     <Create {...props} title="UserSiteData Create">
         <SimpleForm validate={validationCreateUserSiteData}>
-            <ReferenceInput label="User" source="user_id" reference="users" perPage={0} allowEmpty>
-                <SelectInput optionText="username" />
-            </ReferenceInput>
+            <UnlimitedDropdownInput
+                label="User"
+                source="user_id"
+                reference="users"
+                optionText="username"
+                filter={{ site_ids: '' }}
+            />
             <ReferenceInput label="Site" source="site_id" reference="sites" perPage={0} allowEmpty>
                 <SelectInput optionText="name" />
             </ReferenceInput>

--- a/admin/src/resources/UserSiteRole.js
+++ b/admin/src/resources/UserSiteRole.js
@@ -22,6 +22,7 @@ import {
 import PermissionsStore from '../auth/PermissionsStore';
 import EmptyField from '../fields/EmptyField';
 import UserSiteRoleFilter from '../filters/UserSiteRoleFilter';
+import UnlimitedDropdownInput from '../inputs/UnlimitedDropdownInput';
 
 const validationCreateUserSiteRole = values => {
     const errors = {};
@@ -72,9 +73,13 @@ export const UserSiteRoleList = props => (
 export const UserSiteRoleCreate = props => (
     <Create {...props} title="UserSiteRole Create">
         <SimpleForm validate={validationCreateUserSiteRole}>
-            <ReferenceInput label="User" source="user_id" reference="users" perPage={0} allowEmpty>
-                <SelectInput optionText="username" />
-            </ReferenceInput>
+            <UnlimitedDropdownInput
+                label="User"
+                source="user_id"
+                reference="users"
+                optionText="username"
+                filter={{ site_ids: '' }}
+            />
             <ReferenceInput label="Site" source="site_id" reference="sites" perPage={0} allowEmpty>
                 <SelectInput optionText="name" />
             </ReferenceInput>

--- a/admin/src/swaggerRestServer.js
+++ b/admin/src/swaggerRestServer.js
@@ -65,12 +65,14 @@ const FILTER_LENGTHS = {
 
 // These are default filters that were required for the
 // context implied filter. Permanent filter props on listings were not
-// used as they could not be overridden.
-const DEFAULT_FILTERS = {
+// used as they could not be overridden. To override the default provide
+// the same filter in your restClient call. eg. `{ site_ids: '' }`
+// NOTE: Must be a function as the PermissionsStore can change.
+const DEFAULT_FILTERS = () => ({
     users: {
         site_ids: PermissionsStore.getSiteIDs()
     }
-};
+});
 
 /**
  * @param {String} apiUrl The base API url
@@ -104,7 +106,7 @@ export const convertRESTRequestToHTTP = ({ apiUrl, type, resource, params }) => 
 
             if (params.filter) {
                 let filterLengths = FILTER_LENGTHS[resource];
-                const defaultFilters = DEFAULT_FILTERS[resource];
+                const defaultFilters = DEFAULT_FILTERS()[resource];
                 if (defaultFilters) {
                     query = {
                         ...query,

--- a/admin/src/utils.js
+++ b/admin/src/utils.js
@@ -1,5 +1,4 @@
 import restClient, { GET_LIST, OPERATIONAL } from './swaggerRestServer';
-import PermissionsStore from './auth/PermissionsStore';
 
 /**
  * Generated utils.js code. Edit at own risk.

--- a/admin/src/utils.js
+++ b/admin/src/utils.js
@@ -1,9 +1,27 @@
-import restClient, { GET_LIST } from './swaggerRestServer';
+import restClient, { GET_LIST, OPERATIONAL } from './swaggerRestServer';
+import PermissionsStore from './auth/PermissionsStore';
 
 /**
  * Generated utils.js code. Edit at own risk.
  * When regenerated the changes will be lost.
  **/
+export const getSitesForContext = async (currentContext) => {
+    if (currentContext) {
+        const [contextType, contextID] = currentContext.key.split(':');
+        if (contextType === 's') {
+            return contextID;
+        }
+        let results = await restClient(OPERATIONAL, 'get_sites_under_domain', {
+            pathParameters: [contextID]
+        });
+        results = results.data;
+        const site_ids = getUniqueIDs(results, 'id').join(',');
+        return site_ids;
+    } else {
+        return '';
+    }
+};
+
 export const getUntilDone = async (resource, filter = {}, perPage, maxAttempts = 10) => {
     let collection = [];
     let done = false;

--- a/admin/src/utils.js
+++ b/admin/src/utils.js
@@ -4,7 +4,11 @@ import restClient, { GET_LIST, OPERATIONAL } from './swaggerRestServer';
  * Generated utils.js code. Edit at own risk.
  * When regenerated the changes will be lost.
  **/
-export const getSitesForContext = async (currentContext) => {
+// This exists to check if the string for the array filters have more than
+// one id in them. eg idsInString == '5,7,12'
+export const moreThanOneID = idsInString => idsInString.split(',').length > 1;
+
+export const getSitesForContext = async currentContext => {
     if (currentContext) {
         const [contextType, contextID] = currentContext.key.split(':');
         if (contextType === 's') {


### PR DESCRIPTION
**Background:** The main user search page listing is currently not affected by the current context of the GMP.

**What was done:** If the current context is a domain, all site in the tree under that domain are retrieved and loaded into the store. If the current context is a site that is loaded into store as the single site context. The default filters are now in the restClient (as the permanent `filter` props AOR provides CANNOT be overridden). The default filters can be overridden by just specifying them if you would like. 