### PR TITLE
Feature/send invite mail action

### DIFF
--- a/admin/src/Theme.js
+++ b/admin/src/Theme.js
@@ -20,6 +20,11 @@ export const styles = {
     card: {
         minWidth: 300
     },
+    cardAction: {
+        zIndex: 2,
+        display: 'inline-block',
+        float: 'right',
+    },
     avatar: {
         margin: '1em',
         textAlign: 'center '

--- a/admin/src/auth/OIDCCallback.js
+++ b/admin/src/auth/OIDCCallback.js
@@ -4,7 +4,7 @@ import React, { Component } from 'react';
 import { Redirect } from 'react-router';
 
 import PermissionsStore from '../auth/PermissionsStore';
-import { base64urlDecode, errorNotificationAnt, generateQueryString } from '../utils';
+import { base64urlDecode, errorNotificationAnt } from '../utils';
 import WaitingPage from '../pages/WaitingPage';
 
 class OIDCCallback extends Component {

--- a/admin/src/customActions/Invitation.js
+++ b/admin/src/customActions/Invitation.js
@@ -1,19 +1,57 @@
-import React from 'react';
+import React, { Component } from 'react';
 import { CardActions } from 'material-ui/Card';
 import FlatButton from 'material-ui/FlatButton';
+import SendIcon from 'material-ui/svg-icons/content/send';
 import { DeleteButton, ListButton, RefreshButton, ShowButton } from 'admin-on-rest';
 
+import restClient, { OPERATIONAL } from '../swaggerRestServer';
 import { styles } from '../Theme';
+import { successNotificationAnt, errorNotificationAnt } from '../utils';
 
-const InvitationEditActions = ({ basePath, data }) => (
-    <CardActions style={styles.cardAction}>
-        <ShowButton basePath={basePath} record={data} />
-        <ListButton basePath={basePath} />
-        <DeleteButton basePath={basePath} record={data} />
-        <RefreshButton />
-        {/* Custom Actions */}
-        <FlatButton primary label="Custom Action" onClick={console.log('here')} />
-    </CardActions>
-);
+class InvitationEditActions extends Component {
+    constructor(props) {
+        super(props);
+        this.inviteNotExpired = this.inviteNotExpired.bind(this);
+        this.sendInvite = this.sendInvite.bind(this);
+    }
+    inviteNotExpired() {
+        if (this.props.data) {
+            const expiryDate = new Date(this.props.data.expires_at);
+            return expiryDate < new Date();
+        }
+        return false;
+    }
+    sendInvite() {
+        const data = this.props.data;
+        restClient(OPERATIONAL, `/invitations/${data.id}/send`, {})
+            .then(response => {
+                successNotificationAnt('Invite Sent!');
+            })
+            .catch(error => {
+                console.error(error);
+                errorNotificationAnt('Invite not sent.');
+            });
+    }
+    render() {
+        const { basePath, data } = this.props;
+        return (
+            <CardActions style={styles.cardAction}>
+                <ShowButton basePath={basePath} record={data} />
+                <ListButton basePath={basePath} />
+                <DeleteButton basePath={basePath} record={data} />
+                <RefreshButton />
+                {/* Custom Actions */}
+                {this.inviteNotExpired() && (
+                    <FlatButton
+                        primary
+                        icon={<SendIcon />}
+                        label="Send Invite"
+                        onClick={this.sendInvite}
+                    />
+                )}
+            </CardActions>
+        );
+    }
+}
 
 export default InvitationEditActions;

--- a/admin/src/customActions/Invitation.js
+++ b/admin/src/customActions/Invitation.js
@@ -4,9 +4,10 @@ import FlatButton from 'material-ui/FlatButton';
 import SendIcon from 'material-ui/svg-icons/content/send';
 import { DeleteButton, ListButton, RefreshButton, ShowButton } from 'admin-on-rest';
 
-import restClient, { OPERATIONAL } from '../swaggerRestServer';
 import { styles } from '../Theme';
 import { successNotificationAnt, errorNotificationAnt } from '../utils';
+
+const timezoneOffset = new Date().getTimezoneOffset();
 
 class InvitationEditActions extends Component {
     constructor(props) {
@@ -14,24 +15,29 @@ class InvitationEditActions extends Component {
         this.inviteNotExpired = this.inviteNotExpired.bind(this);
         this.sendInvite = this.sendInvite.bind(this);
     }
+
     inviteNotExpired() {
         if (this.props.data) {
             const expiryDate = new Date(this.props.data.expires_at);
-            return expiryDate < new Date();
+            let now = new Date();
+            now = new Date(now.valueOf() - timezoneOffset * 60000);
+            return expiryDate > now;
         }
         return false;
     }
+
     sendInvite() {
         const data = this.props.data;
-        restClient(OPERATIONAL, `/invitations/${data.id}/send`, {})
+        fetch(`/invitations/${data.id}/send`, { method: 'GET' })
             .then(response => {
-                successNotificationAnt('Invite Sent!');
+                successNotificationAnt('An invitation email was successfully queued for sending.');
             })
             .catch(error => {
                 console.error(error);
                 errorNotificationAnt('Invite not sent.');
             });
     }
+
     render() {
         const { basePath, data } = this.props;
         return (

--- a/admin/src/customActions/Invitation.js
+++ b/admin/src/customActions/Invitation.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import { CardActions } from 'material-ui/Card';
+import FlatButton from 'material-ui/FlatButton';
+import { DeleteButton, ListButton, RefreshButton, ShowButton } from 'admin-on-rest';
+
+import { styles } from '../Theme';
+
+const InvitationEditActions = ({ basePath, data }) => (
+    <CardActions style={styles.cardAction}>
+        <ShowButton basePath={basePath} record={data} />
+        <ListButton basePath={basePath} />
+        <DeleteButton basePath={basePath} record={data} />
+        <RefreshButton />
+        {/* Custom Actions */}
+        <FlatButton primary label="Custom Action" onClick={console.log('here')} />
+    </CardActions>
+);
+
+export default InvitationEditActions;

--- a/admin/src/customActions/Invitation.js
+++ b/admin/src/customActions/Invitation.js
@@ -2,14 +2,14 @@ import React, { Component } from 'react';
 import { CardActions } from 'material-ui/Card';
 import FlatButton from 'material-ui/FlatButton';
 import SendIcon from 'material-ui/svg-icons/content/send';
-import { DeleteButton, ListButton, RefreshButton, ShowButton } from 'admin-on-rest';
+import { DeleteButton, ListButton, RefreshButton, EditButton } from 'admin-on-rest';
 
 import { styles } from '../Theme';
 import { successNotificationAnt, errorNotificationAnt } from '../utils';
 
 const timezoneOffset = new Date().getTimezoneOffset();
 
-class InvitationEditActions extends Component {
+class InvitationShowActions extends Component {
     constructor(props) {
         super(props);
         this.inviteNotExpired = this.inviteNotExpired.bind(this);
@@ -42,7 +42,7 @@ class InvitationEditActions extends Component {
         const { basePath, data } = this.props;
         return (
             <CardActions style={styles.cardAction}>
-                <ShowButton basePath={basePath} record={data} />
+                <EditButton basePath={basePath} record={data} />
                 <ListButton basePath={basePath} />
                 <DeleteButton basePath={basePath} record={data} />
                 <RefreshButton />
@@ -60,4 +60,4 @@ class InvitationEditActions extends Component {
     }
 }
 
-export default InvitationEditActions;
+export default InvitationShowActions;

--- a/admin/src/inputs/DateRangeInput.js
+++ b/admin/src/inputs/DateRangeInput.js
@@ -36,7 +36,7 @@ class DateRangeInput extends Component {
     }
 
     dateParser(value) {
-        // Value recieved is a string in the DateInput.
+        // Value received is a string in the DateInput.
         const regexp = /(\d{4})-(\d{2})-(\d{2})/;
         let match = regexp.exec(value);
         if (match === null) return;
@@ -60,7 +60,7 @@ class DateRangeInput extends Component {
     }
 
     dateTimeFormatter(value) {
-        // Value recieved is a date object in the DateTimeInput.
+        // Value received is a date object in the DateTimeInput.
         if (timezoneOffset !== 0 && value) {
             value = new Date(value);
             value = new Date(value.valueOf() + timezoneOffset * 60000);
@@ -69,7 +69,7 @@ class DateRangeInput extends Component {
     }
 
     dateTimeParser(value) {
-        // Value recieved is a date object in the DateTimeInput.
+        // Value received is a date object in the DateTimeInput.
         if (timezoneOffset !== 0 && value) {
             value = new Date(value.valueOf() - timezoneOffset * 60000);
         }

--- a/admin/src/pages/NoPermissions.js
+++ b/admin/src/pages/NoPermissions.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { logout } from 'admin-on-rest';
 import NotAllowed from 'material-ui/svg-icons/av/not-interested';
 
 import { styles } from '../Theme';

--- a/admin/src/resources/AdminNote.js
+++ b/admin/src/resources/AdminNote.js
@@ -39,12 +39,12 @@ const validationCreateAdminNote = values => {
         errors.note = ["note is required"];
     }
     return errors;
-}
+};
 
 const validationEditAdminNote = values => {
     const errors = {};
     return errors;
-}
+};
 
 export const AdminNoteList = props => (
     <List {...props} title="AdminNote List" filters={<AdminNoteFilter />}>
@@ -72,7 +72,7 @@ export const AdminNoteList = props => (
             {PermissionsStore.getResourcePermission('adminnotes', 'remove') ? <DeleteButton />: null}
         </Datagrid>
     </List>
-)
+);
 
 export const AdminNoteCreate = props => (
     <Create {...props} title="AdminNote Create">
@@ -86,7 +86,7 @@ export const AdminNoteCreate = props => (
             <TextInput source="note" />
         </SimpleForm>
     </Create>
-)
+);
 
 export const AdminNoteShow = props => (
     <Show {...props} title="AdminNote Show">
@@ -111,7 +111,7 @@ export const AdminNoteShow = props => (
             <DateField source="updated_at" />
         </SimpleShowLayout>
     </Show>
-)
+);
 
 export const AdminNoteEdit = props => (
     <Edit {...props} title="AdminNote Edit">
@@ -119,6 +119,6 @@ export const AdminNoteEdit = props => (
             <TextInput source="note" />
         </SimpleForm>
     </Edit>
-)
+);
 
 /** End of Generated Code **/

--- a/admin/src/resources/Client.js
+++ b/admin/src/resources/Client.js
@@ -33,7 +33,7 @@ export const ClientList = props => (
             <ShowButton />
         </Datagrid>
     </List>
-)
+);
 
 export const ClientShow = props => (
     <Show {...props} title="Client Show">
@@ -52,6 +52,6 @@ export const ClientShow = props => (
             <TextField source="website_url" />
         </SimpleShowLayout>
     </Show>
-)
+);
 
 /** End of Generated Code **/

--- a/admin/src/resources/Country.js
+++ b/admin/src/resources/Country.js
@@ -21,7 +21,7 @@ export const CountryList = props => (
             <ShowButton />
         </Datagrid>
     </List>
-)
+);
 
 export const CountryShow = props => (
     <Show {...props} title="Country Show">
@@ -30,6 +30,6 @@ export const CountryShow = props => (
             <TextField source="name" />
         </SimpleShowLayout>
     </Show>
-)
+);
 
 /** End of Generated Code **/

--- a/admin/src/resources/Domain.js
+++ b/admin/src/resources/Domain.js
@@ -34,12 +34,12 @@ const validationCreateDomain = values => {
         errors.name = ["name is required"];
     }
     return errors;
-}
+};
 
 const validationEditDomain = values => {
     const errors = {};
     return errors;
-}
+};
 
 export const DomainList = props => (
     <List {...props} title="Domain List" filters={<DomainFilter />}>
@@ -61,7 +61,7 @@ export const DomainList = props => (
             {PermissionsStore.getResourcePermission('domains', 'remove') ? <DeleteButton />: null}
         </Datagrid>
     </List>
-)
+);
 
 export const DomainCreate = props => (
     <Create {...props} title="Domain Create">
@@ -73,7 +73,7 @@ export const DomainCreate = props => (
             <TextInput source="description" />
         </SimpleForm>
     </Create>
-)
+);
 
 export const DomainShow = props => (
     <Show {...props} title="Domain Show">
@@ -118,7 +118,7 @@ export const DomainShow = props => (
             )}
         </SimpleShowLayout>
     </Show>
-)
+);
 
 export const DomainEdit = props => (
     <Edit {...props} title="Domain Edit">
@@ -156,6 +156,6 @@ export const DomainEdit = props => (
             )}
         </SimpleForm>
     </Edit>
-)
+);
 
 /** End of Generated Code **/

--- a/admin/src/resources/DomainRole.js
+++ b/admin/src/resources/DomainRole.js
@@ -36,12 +36,12 @@ const validationCreateDomainRole = values => {
         errors.role_id = ["role_id is required"];
     }
     return errors;
-}
+};
 
 const validationEditDomainRole = values => {
     const errors = {};
     return errors;
-}
+};
 
 export const DomainRoleList = props => (
     <List {...props} title="DomainRole List" filters={<DomainRoleFilter />}>
@@ -68,7 +68,7 @@ export const DomainRoleList = props => (
             {PermissionsStore.getResourcePermission('domainroles', 'remove') ? <DeleteButton />: null}
         </Datagrid>
     </List>
-)
+);
 
 export const DomainRoleCreate = props => (
     <Create {...props} title="DomainRole Create">
@@ -80,7 +80,7 @@ export const DomainRoleCreate = props => (
             <BooleanInput source="grant_implicitly" />
         </SimpleForm>
     </Create>
-)
+);
 
 export const DomainRoleShow = props => (
     <Show {...props} title="DomainRole Show">
@@ -104,7 +104,7 @@ export const DomainRoleShow = props => (
             <DateField source="updated_at" />
         </SimpleShowLayout>
     </Show>
-)
+);
 
 export const DomainRoleEdit = props => (
     <Edit {...props} title="DomainRole Edit">
@@ -112,6 +112,6 @@ export const DomainRoleEdit = props => (
             <BooleanInput source="grant_implicitly" />
         </SimpleForm>
     </Edit>
-)
+);
 
 /** End of Generated Code **/

--- a/admin/src/resources/Invitation.js
+++ b/admin/src/resources/Invitation.js
@@ -29,6 +29,25 @@ import DateTimeInput from 'aor-datetime-input';
 import InvitationFilter from '../filters/InvitationFilter';
 import InvitationEditActions from '../customActions/Invitation';
 
+const timezoneOffset = new Date().getTimezoneOffset();
+
+const dateTimeFormatter = value => {
+    // Value received is a date object in the DateTimeInput.
+    if (timezoneOffset !== 0 && value) {
+        value = new Date(value);
+        value = new Date(value.valueOf() + timezoneOffset * 60000);
+    }
+    return value;
+};
+
+const dateTimeParser = value => {
+    // Value received is a date object in the DateTimeInput.
+    if (timezoneOffset !== 0 && value) {
+        value = new Date(value.valueOf() - timezoneOffset * 60000);
+    }
+    return value;
+};
+
 const validationCreateInvitation = values => {
     const errors = {};
     if (!values.first_name) {
@@ -44,12 +63,12 @@ const validationCreateInvitation = values => {
         errors.organisation_id = ["organisation_id is required"];
     }
     return errors;
-}
+};
 
 const validationEditInvitation = values => {
     const errors = {};
     return errors;
-}
+};
 
 export const InvitationList = props => (
     <List {...props} title="Invitation List" filters={<InvitationFilter />}>
@@ -80,7 +99,7 @@ export const InvitationList = props => (
             {PermissionsStore.getResourcePermission('invitations', 'remove') ? <DeleteButton />: null}
         </Datagrid>
     </List>
-)
+);
 
 export const InvitationCreate = props => (
     <Create {...props} title="Invitation Create">
@@ -91,10 +110,10 @@ export const InvitationCreate = props => (
             <ReferenceInput label="Organisation" source="organisation_id" reference="organisations" perPage={0} allowEmpty>
                 <SelectInput optionText="name" />
             </ReferenceInput>
-            <DateTimeInput source="expires_at" />
+            <DateTimeInput source="expires_at" format={dateTimeFormatter} parse={dateTimeParser} />
         </SimpleForm>
     </Create>
-)
+);
 
 export const InvitationShow = props => (
     <Show {...props} title="Invitation Show">
@@ -154,7 +173,7 @@ export const InvitationShow = props => (
             )}
         </SimpleShowLayout>
     </Show>
-)
+);
 
 export const InvitationEdit = props => (
     <Edit {...props} actions={<InvitationEditActions/>} title="Invitation Edit">
@@ -165,7 +184,7 @@ export const InvitationEdit = props => (
             <ReferenceInput label="Organisation" source="organisation_id" reference="organisations" perPage={0} allowEmpty>
                 <SelectInput optionText="name" />
             </ReferenceInput>
-            <DateTimeInput source="expires_at" />
+            <DateTimeInput source="expires_at" format={dateTimeFormatter} parse={dateTimeParser} />
             {PermissionsStore.getResourcePermission('invitationdomainroles', 'list') ? (
                 <ReferenceManyField label="Domain Roles" reference="invitationdomainroles" target="invitation_id">
                     <Datagrid bodyOptions={ { showRowHover: true } }>
@@ -200,6 +219,6 @@ export const InvitationEdit = props => (
             )}
         </SimpleForm>
     </Edit>
-)
+);
 
 /** End of Generated Code **/

--- a/admin/src/resources/Invitation.js
+++ b/admin/src/resources/Invitation.js
@@ -27,6 +27,7 @@ import PermissionsStore from '../auth/PermissionsStore';
 import EmptyField from '../fields/EmptyField';
 import DateTimeInput from 'aor-datetime-input';
 import InvitationFilter from '../filters/InvitationFilter';
+import InvitationEditActions from '../customActions/Invitation';
 
 const validationCreateInvitation = values => {
     const errors = {};
@@ -156,7 +157,7 @@ export const InvitationShow = props => (
 )
 
 export const InvitationEdit = props => (
-    <Edit {...props} title="Invitation Edit">
+    <Edit {...props} actions={<InvitationEditActions/>} title="Invitation Edit">
         <SimpleForm validate={validationEditInvitation}>
             <TextInput source="first_name" />
             <TextInput source="last_name" />

--- a/admin/src/resources/Invitation.js
+++ b/admin/src/resources/Invitation.js
@@ -27,7 +27,7 @@ import PermissionsStore from '../auth/PermissionsStore';
 import EmptyField from '../fields/EmptyField';
 import DateTimeInput from 'aor-datetime-input';
 import InvitationFilter from '../filters/InvitationFilter';
-import InvitationEditActions from '../customActions/Invitation';
+import InvitationShowActions from '../customActions/Invitation';
 
 const timezoneOffset = new Date().getTimezoneOffset();
 
@@ -116,7 +116,7 @@ export const InvitationCreate = props => (
 );
 
 export const InvitationShow = props => (
-    <Show {...props} title="Invitation Show">
+    <Show {...props} actions={<InvitationShowActions />} title="Invitation Show">
         <SimpleShowLayout>
             <TextField source="id" />
             {PermissionsStore.getResourcePermission('users', 'list') ? (
@@ -176,7 +176,7 @@ export const InvitationShow = props => (
 );
 
 export const InvitationEdit = props => (
-    <Edit {...props} actions={<InvitationEditActions/>} title="Invitation Edit">
+    <Edit {...props} title="Invitation Edit">
         <SimpleForm validate={validationEditInvitation}>
             <TextInput source="first_name" />
             <TextInput source="last_name" />

--- a/admin/src/resources/InvitationDomainRole.js
+++ b/admin/src/resources/InvitationDomainRole.js
@@ -36,7 +36,7 @@ const validationCreateInvitationDomainRole = values => {
         errors.role_id = ["role_id is required"];
     }
     return errors;
-}
+};
 
 export const InvitationDomainRoleList = props => (
     <List {...props} title="InvitationDomainRole List" filters={<InvitationDomainRoleFilter />}>
@@ -68,7 +68,7 @@ export const InvitationDomainRoleList = props => (
             {PermissionsStore.getResourcePermission('invitationdomainroles', 'remove') ? <DeleteButton />: null}
         </Datagrid>
     </List>
-)
+);
 
 export const InvitationDomainRoleCreate = props => (
     <Create {...props} title="InvitationDomainRole Create">
@@ -82,7 +82,7 @@ export const InvitationDomainRoleCreate = props => (
             </ReferenceInput>
         </SimpleForm>
     </Create>
-)
+);
 
 export const InvitationDomainRoleShow = props => (
     <Show {...props} title="InvitationDomainRole Show">
@@ -112,6 +112,6 @@ export const InvitationDomainRoleShow = props => (
             <DateField source="updated_at" />
         </SimpleShowLayout>
     </Show>
-)
+);
 
 /** End of Generated Code **/

--- a/admin/src/resources/InvitationSiteRole.js
+++ b/admin/src/resources/InvitationSiteRole.js
@@ -35,7 +35,7 @@ const validationCreateInvitationSiteRole = values => {
         errors.role_id = ["role_id is required"];
     }
     return errors;
-}
+};
 
 export const InvitationSiteRoleList = props => (
     <List {...props} title="InvitationSiteRole List" filters={<InvitationSiteRoleFilter />}>
@@ -67,7 +67,7 @@ export const InvitationSiteRoleList = props => (
             {PermissionsStore.getResourcePermission('invitationsiteroles', 'remove') ? <DeleteButton />: null}
         </Datagrid>
     </List>
-)
+);
 
 export const InvitationSiteRoleCreate = props => (
     <Create {...props} title="InvitationSiteRole Create">
@@ -83,7 +83,7 @@ export const InvitationSiteRoleCreate = props => (
             </ReferenceInput>
         </SimpleForm>
     </Create>
-)
+);
 
 export const InvitationSiteRoleShow = props => (
     <Show {...props} title="InvitationSiteRole Show">
@@ -113,6 +113,6 @@ export const InvitationSiteRoleShow = props => (
             <DateField source="updated_at" />
         </SimpleShowLayout>
     </Show>
-)
+);
 
 /** End of Generated Code **/

--- a/admin/src/resources/Organisation.js
+++ b/admin/src/resources/Organisation.js
@@ -28,12 +28,12 @@ const validationCreateOrganisation = values => {
         errors.name = ["name is required"];
     }
     return errors;
-}
+};
 
 const validationEditOrganisation = values => {
     const errors = {};
     return errors;
-}
+};
 
 export const OrganisationList = props => (
     <List {...props} title="Organisation List" filters={<OrganisationFilter />}>
@@ -48,7 +48,7 @@ export const OrganisationList = props => (
             {PermissionsStore.getResourcePermission('organisations', 'remove') ? <DeleteButton />: null}
         </Datagrid>
     </List>
-)
+);
 
 export const OrganisationCreate = props => (
     <Create {...props} title="Organisation Create">
@@ -57,7 +57,7 @@ export const OrganisationCreate = props => (
             <TextInput source="description" />
         </SimpleForm>
     </Create>
-)
+);
 
 export const OrganisationShow = props => (
     <Show {...props} title="Organisation Show">
@@ -69,7 +69,7 @@ export const OrganisationShow = props => (
             <DateField source="updated_at" />
         </SimpleShowLayout>
     </Show>
-)
+);
 
 export const OrganisationEdit = props => (
     <Edit {...props} title="Organisation Edit">
@@ -78,6 +78,6 @@ export const OrganisationEdit = props => (
             <TextInput source="description" />
         </SimpleForm>
     </Edit>
-)
+);
 
 /** End of Generated Code **/

--- a/admin/src/resources/Permission.js
+++ b/admin/src/resources/Permission.js
@@ -28,12 +28,12 @@ const validationCreatePermission = values => {
         errors.name = ["name is required"];
     }
     return errors;
-}
+};
 
 const validationEditPermission = values => {
     const errors = {};
     return errors;
-}
+};
 
 export const PermissionList = props => (
     <List {...props} title="Permission List" filters={<PermissionFilter />}>
@@ -48,7 +48,7 @@ export const PermissionList = props => (
             {PermissionsStore.getResourcePermission('permissions', 'remove') ? <DeleteButton />: null}
         </Datagrid>
     </List>
-)
+);
 
 export const PermissionCreate = props => (
     <Create {...props} title="Permission Create">
@@ -57,7 +57,7 @@ export const PermissionCreate = props => (
             <TextInput source="description" />
         </SimpleForm>
     </Create>
-)
+);
 
 export const PermissionShow = props => (
     <Show {...props} title="Permission Show">
@@ -69,7 +69,7 @@ export const PermissionShow = props => (
             <DateField source="updated_at" />
         </SimpleShowLayout>
     </Show>
-)
+);
 
 export const PermissionEdit = props => (
     <Edit {...props} title="Permission Edit">
@@ -78,6 +78,6 @@ export const PermissionEdit = props => (
             <TextInput source="description" />
         </SimpleForm>
     </Edit>
-)
+);
 
 /** End of Generated Code **/

--- a/admin/src/resources/Resource.js
+++ b/admin/src/resources/Resource.js
@@ -28,12 +28,12 @@ const validationCreateResource = values => {
         errors.urn = ["urn is required"];
     }
     return errors;
-}
+};
 
 const validationEditResource = values => {
     const errors = {};
     return errors;
-}
+};
 
 export const ResourceList = props => (
     <List {...props} title="Resource List" filters={<ResourceFilter />}>
@@ -48,7 +48,7 @@ export const ResourceList = props => (
             {PermissionsStore.getResourcePermission('resources', 'remove') ? <DeleteButton />: null}
         </Datagrid>
     </List>
-)
+);
 
 export const ResourceCreate = props => (
     <Create {...props} title="Resource Create">
@@ -57,7 +57,7 @@ export const ResourceCreate = props => (
             <TextInput source="description" />
         </SimpleForm>
     </Create>
-)
+);
 
 export const ResourceShow = props => (
     <Show {...props} title="Resource Show">
@@ -69,7 +69,7 @@ export const ResourceShow = props => (
             <DateField source="updated_at" />
         </SimpleShowLayout>
     </Show>
-)
+);
 
 export const ResourceEdit = props => (
     <Edit {...props} title="Resource Edit">
@@ -78,6 +78,6 @@ export const ResourceEdit = props => (
             <TextInput source="description" />
         </SimpleForm>
     </Edit>
-)
+);
 
 /** End of Generated Code **/

--- a/admin/src/resources/Role.js
+++ b/admin/src/resources/Role.js
@@ -33,12 +33,12 @@ const validationCreateRole = values => {
         errors.label = ["label is required"];
     }
     return errors;
-}
+};
 
 const validationEditRole = values => {
     const errors = {};
     return errors;
-}
+};
 
 export const RoleList = props => (
     <List {...props} title="Role List" filters={<RoleFilter />}>
@@ -54,7 +54,7 @@ export const RoleList = props => (
             {PermissionsStore.getResourcePermission('roles', 'remove') ? <DeleteButton />: null}
         </Datagrid>
     </List>
-)
+);
 
 export const RoleCreate = props => (
     <Create {...props} title="Role Create">
@@ -64,7 +64,7 @@ export const RoleCreate = props => (
             <TextInput source="description" />
         </SimpleForm>
     </Create>
-)
+);
 
 export const RoleShow = props => (
     <Show {...props} title="Role Show">
@@ -93,7 +93,7 @@ export const RoleShow = props => (
             )}
         </SimpleShowLayout>
     </Show>
-)
+);
 
 export const RoleEdit = props => (
     <Edit {...props} title="Role Edit">
@@ -119,6 +119,6 @@ export const RoleEdit = props => (
             )}
         </SimpleForm>
     </Edit>
-)
+);
 
 /** End of Generated Code **/

--- a/admin/src/resources/RoleResourcePermission.js
+++ b/admin/src/resources/RoleResourcePermission.js
@@ -34,7 +34,7 @@ const validationCreateRoleResourcePermission = values => {
         errors.permission_id = ["permission_id is required"];
     }
     return errors;
-}
+};
 
 export const RoleResourcePermissionList = props => (
     <List {...props} title="RoleResourcePermission List" filters={<RoleResourcePermissionFilter />}>
@@ -66,7 +66,7 @@ export const RoleResourcePermissionList = props => (
             {PermissionsStore.getResourcePermission('roleresourcepermissions', 'remove') ? <DeleteButton />: null}
         </Datagrid>
     </List>
-)
+);
 
 export const RoleResourcePermissionCreate = props => (
     <Create {...props} title="RoleResourcePermission Create">
@@ -82,7 +82,7 @@ export const RoleResourcePermissionCreate = props => (
             </ReferenceInput>
         </SimpleForm>
     </Create>
-)
+);
 
 export const RoleResourcePermissionShow = props => (
     <Show {...props} title="RoleResourcePermission Show">
@@ -112,6 +112,6 @@ export const RoleResourcePermissionShow = props => (
             <DateField source="updated_at" />
         </SimpleShowLayout>
     </Show>
-)
+);
 
 /** End of Generated Code **/

--- a/admin/src/resources/Site.js
+++ b/admin/src/resources/Site.js
@@ -39,12 +39,12 @@ const validationCreateSite = values => {
         errors.name = ["name is required"];
     }
     return errors;
-}
+};
 
 const validationEditSite = values => {
     const errors = {};
     return errors;
-}
+};
 
 export const SiteList = props => (
     <List {...props} title="Site List" filters={<SiteFilter />}>
@@ -74,7 +74,7 @@ export const SiteList = props => (
             {PermissionsStore.getResourcePermission('sites', 'remove') ? <DeleteButton />: null}
         </Datagrid>
     </List>
-)
+);
 
 export const SiteCreate = props => (
     <Create {...props} title="Site Create">
@@ -90,7 +90,7 @@ export const SiteCreate = props => (
             <TextInput source="description" />
         </SimpleForm>
     </Create>
-)
+);
 
 export const SiteShow = props => (
     <Show {...props} title="Site Show">
@@ -131,7 +131,7 @@ export const SiteShow = props => (
             )}
         </SimpleShowLayout>
     </Show>
-)
+);
 
 export const SiteEdit = props => (
     <Edit {...props} title="Site Edit">
@@ -161,6 +161,6 @@ export const SiteEdit = props => (
             )}
         </SimpleForm>
     </Edit>
-)
+);
 
 /** End of Generated Code **/

--- a/admin/src/resources/SiteDataSchema.js
+++ b/admin/src/resources/SiteDataSchema.js
@@ -35,12 +35,12 @@ const validationCreateSiteDataSchema = values => {
         errors.schema = ["schema is required"];
     }
     return errors;
-}
+};
 
 const validationEditSiteDataSchema = values => {
     const errors = {};
     return errors;
-}
+};
 
 export const SiteDataSchemaList = props => (
     <List {...props} title="SiteDataSchema List" filters={<SiteDataSchemaFilter />}>
@@ -60,7 +60,7 @@ export const SiteDataSchemaList = props => (
             {PermissionsStore.getResourcePermission('sitedataschemas', 'remove') ? <DeleteButton />: null}
         </Datagrid>
     </List>
-)
+);
 
 export const SiteDataSchemaCreate = props => (
     <Create {...props} title="SiteDataSchema Create">
@@ -71,7 +71,7 @@ export const SiteDataSchemaCreate = props => (
             <LongTextInput source="schema" format={value => value instanceof Object ? JSON.stringify(value) : value} parse={value => { try { return JSON.parse(value); } catch (e) { return value; } }} />
         </SimpleForm>
     </Create>
-)
+);
 
 export const SiteDataSchemaShow = props => (
     <Show {...props} title="SiteDataSchema Show">
@@ -88,7 +88,7 @@ export const SiteDataSchemaShow = props => (
             <DateField source="updated_at" />
         </SimpleShowLayout>
     </Show>
-)
+);
 
 export const SiteDataSchemaEdit = props => (
     <Edit {...props} title="SiteDataSchema Edit">
@@ -96,6 +96,6 @@ export const SiteDataSchemaEdit = props => (
             <LongTextInput source="schema" format={value => value instanceof Object ? JSON.stringify(value) : value} parse={value => { try { return JSON.parse(value); } catch (e) { return value; } }} />
         </SimpleForm>
     </Edit>
-)
+);
 
 /** End of Generated Code **/

--- a/admin/src/resources/SiteRole.js
+++ b/admin/src/resources/SiteRole.js
@@ -35,12 +35,12 @@ const validationCreateSiteRole = values => {
         errors.role_id = ["role_id is required"];
     }
     return errors;
-}
+};
 
 const validationEditSiteRole = values => {
     const errors = {};
     return errors;
-}
+};
 
 export const SiteRoleList = props => (
     <List {...props} title="SiteRole List" filters={<SiteRoleFilter />}>
@@ -67,7 +67,7 @@ export const SiteRoleList = props => (
             {PermissionsStore.getResourcePermission('siteroles', 'remove') ? <DeleteButton />: null}
         </Datagrid>
     </List>
-)
+);
 
 export const SiteRoleCreate = props => (
     <Create {...props} title="SiteRole Create">
@@ -81,7 +81,7 @@ export const SiteRoleCreate = props => (
             <BooleanInput source="grant_implicitly" />
         </SimpleForm>
     </Create>
-)
+);
 
 export const SiteRoleShow = props => (
     <Show {...props} title="SiteRole Show">
@@ -105,7 +105,7 @@ export const SiteRoleShow = props => (
             <DateField source="updated_at" />
         </SimpleShowLayout>
     </Show>
-)
+);
 
 export const SiteRoleEdit = props => (
     <Edit {...props} title="SiteRole Edit">
@@ -113,6 +113,6 @@ export const SiteRoleEdit = props => (
             <BooleanInput source="grant_implicitly" />
         </SimpleForm>
     </Edit>
-)
+);
 
 /** End of Generated Code **/

--- a/admin/src/resources/User.js
+++ b/admin/src/resources/User.js
@@ -38,7 +38,7 @@ import UserFilter from '../filters/UserFilter';
 const validationEditUser = values => {
     const errors = {};
     return errors;
-}
+};
 
 const hiddenFields = ['created_at', 'updated_at', 'avatar', 'country_code'];
 
@@ -89,7 +89,7 @@ export const UserList = props => (
             {PermissionsStore.getResourcePermission('users', 'remove') ? <DeleteButton />: null}
         </FieldSelectDatagrid>
     </List>
-)
+);
 
 export const UserShow = props => (
     <Show {...props} title="User Show">
@@ -172,7 +172,7 @@ export const UserShow = props => (
             )}
         </SimpleShowLayout>
     </Show>
-)
+);
 
 export const UserEdit = props => (
     <Edit {...props} title="User Edit">
@@ -238,6 +238,6 @@ export const UserEdit = props => (
             )}
         </SimpleForm>
     </Edit>
-)
+);
 
 /** End of Generated Code **/

--- a/admin/src/resources/UserDomainRole.js
+++ b/admin/src/resources/UserDomainRole.js
@@ -37,7 +37,7 @@ const validationCreateUserDomainRole = values => {
         errors.role_id = ["role_id is required"];
     }
     return errors;
-}
+};
 
 export const UserDomainRoleList = props => (
     <List {...props} title="UserDomainRole List" filters={<UserDomainRoleFilter />}>
@@ -69,7 +69,7 @@ export const UserDomainRoleList = props => (
             {PermissionsStore.getResourcePermission('userdomainroles', 'remove') ? <DeleteButton />: null}
         </Datagrid>
     </List>
-)
+);
 
 export const UserDomainRoleCreate = props => (
     <Create {...props} title="UserDomainRole Create">
@@ -87,7 +87,7 @@ export const UserDomainRoleCreate = props => (
             </ReferenceInput>
         </SimpleForm>
     </Create>
-)
+);
 
 export const UserDomainRoleShow = props => (
     <Show {...props} title="UserDomainRole Show">
@@ -117,6 +117,6 @@ export const UserDomainRoleShow = props => (
             <DateField source="updated_at" />
         </SimpleShowLayout>
     </Show>
-)
+);
 
 /** End of Generated Code **/

--- a/admin/src/resources/UserSiteData.js
+++ b/admin/src/resources/UserSiteData.js
@@ -40,12 +40,12 @@ const validationCreateUserSiteData = values => {
         errors.data = ["data is required"];
     }
     return errors;
-}
+};
 
 const validationEditUserSiteData = values => {
     const errors = {};
     return errors;
-}
+};
 
 export const UserSiteDataList = props => (
     <List {...props} title="UserSiteData List" filters={<UserSiteDataFilter />}>
@@ -72,7 +72,7 @@ export const UserSiteDataList = props => (
             {PermissionsStore.getResourcePermission('usersitedata', 'remove') ? <DeleteButton />: null}
         </Datagrid>
     </List>
-)
+);
 
 export const UserSiteDataCreate = props => (
     <Create {...props} title="UserSiteData Create">
@@ -90,7 +90,7 @@ export const UserSiteDataCreate = props => (
             <LongTextInput source="data" format={value => value instanceof Object ? JSON.stringify(value) : value} parse={value => { try { return JSON.parse(value); } catch (e) { return value; } }} />
         </SimpleForm>
     </Create>
-)
+);
 
 export const UserSiteDataShow = props => (
     <Show {...props} title="UserSiteData Show">
@@ -114,7 +114,7 @@ export const UserSiteDataShow = props => (
             <DateField source="updated_at" />
         </SimpleShowLayout>
     </Show>
-)
+);
 
 export const UserSiteDataEdit = props => (
     <Edit {...props} title="UserSiteData Edit">
@@ -122,6 +122,6 @@ export const UserSiteDataEdit = props => (
             <LongTextInput source="data" format={value => value instanceof Object ? JSON.stringify(value) : value} parse={value => { try { return JSON.parse(value); } catch (e) { return value; } }} />
         </SimpleForm>
     </Edit>
-)
+);
 
 /** End of Generated Code **/

--- a/admin/src/resources/UserSiteRole.js
+++ b/admin/src/resources/UserSiteRole.js
@@ -36,7 +36,7 @@ const validationCreateUserSiteRole = values => {
         errors.role_id = ["role_id is required"];
     }
     return errors;
-}
+};
 
 export const UserSiteRoleList = props => (
     <List {...props} title="UserSiteRole List" filters={<UserSiteRoleFilter />}>
@@ -68,7 +68,7 @@ export const UserSiteRoleList = props => (
             {PermissionsStore.getResourcePermission('usersiteroles', 'remove') ? <DeleteButton />: null}
         </Datagrid>
     </List>
-)
+);
 
 export const UserSiteRoleCreate = props => (
     <Create {...props} title="UserSiteRole Create">
@@ -88,7 +88,7 @@ export const UserSiteRoleCreate = props => (
             </ReferenceInput>
         </SimpleForm>
     </Create>
-)
+);
 
 export const UserSiteRoleShow = props => (
     <Show {...props} title="UserSiteRole Show">
@@ -118,6 +118,6 @@ export const UserSiteRoleShow = props => (
             <DateField source="updated_at" />
         </SimpleShowLayout>
     </Show>
-)
+);
 
 /** End of Generated Code **/


### PR DESCRIPTION
**Background:** A send invite endpoint was exposed on the management layer which queues an invite mail send task on the authentication service celery.

**What was done:** A custom `send invite` button was added on the show view of as per the documentation: https://marmelab.com/admin-on-rest/Show.html#actions. This button purely hits the new endpoint and just reports a 200 or a failure to the user. Also the `datetimeinput` surfaced value was fixed using a new formatter and parser as per the AOR documentation: https://marmelab.com/admin-on-rest/Inputs.html#dateinput.  

PS: Some semi colons were added from a regeneration.