### PR TITLE
Feature/geinfra 113

### DIFF
--- a/admin/src/auth/OIDCCallback.js
+++ b/admin/src/auth/OIDCCallback.js
@@ -4,7 +4,7 @@ import React, { Component } from 'react';
 import { Redirect } from 'react-router';
 
 import PermissionsStore from '../auth/PermissionsStore';
-import { base64urlDecode, errorNotificationAnt } from '../utils';
+import { base64urlDecode, errorNotificationAnt, apiErrorHandler } from '../utils';
 import WaitingPage from '../pages/WaitingPage';
 
 class OIDCCallback extends Component {
@@ -68,9 +68,9 @@ class OIDCCallback extends Component {
         }
     }
     handleLoginError(error) {
-        console.error(error);
         localStorage.clear();
         this.setState({ failure: true });
+        apiErrorHandler(error);
         errorNotificationAnt(
             'Something went wrong with your login, please notify us of this issue.'
         );

--- a/admin/src/auth/authClient.js
+++ b/admin/src/auth/authClient.js
@@ -1,5 +1,5 @@
 import { AUTH_LOGOUT, AUTH_CHECK, AUTH_ERROR } from 'admin-on-rest';
-import { generateQueryString } from '../utils';
+import { generateQueryString, apiErrorHandler } from '../utils';
 
 export default (type, params) => {
     if (type === AUTH_LOGOUT) {
@@ -14,7 +14,8 @@ export default (type, params) => {
         }
     }
     if (type === AUTH_ERROR) {
-        if (params.message === 'Token expired') {
+        const invalidToken = apiErrorHandler(params);
+        if (invalidToken) {
             localStorage.removeItem('id_token');
             return Promise.reject();
         }

--- a/admin/src/pages/ContextChanger.js
+++ b/admin/src/pages/ContextChanger.js
@@ -13,7 +13,13 @@ import RaisedButton from 'material-ui/RaisedButton';
 
 import { muiTheme, styles } from '../Theme';
 import PermissionsStore from '../auth/PermissionsStore';
-import { makeIDMapping, getDomainAndSiteIds, createTreeData, getDomainsAndSites } from '../utils';
+import {
+    makeIDMapping,
+    getDomainAndSiteIds,
+    createTreeData,
+    getDomainsAndSites,
+    apiErrorHandler
+} from '../utils';
 import DomainTreeInput from '../inputs/DomainTreeInput';
 
 class ContextChanger extends Component {
@@ -82,11 +88,8 @@ class ContextChanger extends Component {
     }
 
     handleAPIError(error) {
-        if (error.message === 'Token expired') {
-            localStorage.clear();
-            this.setState({ validToken: false });
-        }
-        console.error(error);
+        let validToken = apiErrorHandler(error);
+        this.setState({ validToken });
     }
 
     render() {

--- a/admin/src/pages/ManageUserRoles/AssignRoleCard.js
+++ b/admin/src/pages/ManageUserRoles/AssignRoleCard.js
@@ -15,7 +15,12 @@ import {
     assignRole,
     allAssigned
 } from '../../actions/manageUserRoles';
-import { errorNotificationAnt, notEmptyObject, successNotificationAnt } from '../../utils';
+import {
+    errorNotificationAnt,
+    notEmptyObject,
+    successNotificationAnt,
+    apiErrorHandler
+} from '../../utils';
 import DomainTreeInput from '../../inputs/DomainTreeInput';
 import restClient, { CREATE } from '../../restClient';
 import { PLACE_MAPPING } from '../../constants';
@@ -41,7 +46,6 @@ class AssignRoleCard extends Component {
         this.handleChange = this.handleChange.bind(this);
         this.handleSelect = this.handleSelect.bind(this);
         this.handleAssign = this.handleAssign.bind(this);
-        this.handleAPIError = this.handleAPIError.bind(this);
     }
 
     handleChange(key) {
@@ -114,20 +118,13 @@ class AssignRoleCard extends Component {
                                 }' either exists for the user or the required ${place} role does not exist.`
                             );
                             this.setState({ assigning: count !== amountSelectedToAssign });
-                            this.handleAPIError(error);
+                            const invalidToken = apiErrorHandler(error);
+                            invalidToken && this.props.invalidToken();
                         });
                 }
                 return null;
             });
         }
-    }
-
-    handleAPIError(error) {
-        if (error.message === 'Token expired') {
-            localStorage.clear();
-            this.props.invalidToken();
-        }
-        console.error(error);
     }
 
     render() {

--- a/admin/src/pages/ManageUserRoles/AssignRoleCard.js
+++ b/admin/src/pages/ManageUserRoles/AssignRoleCard.js
@@ -101,10 +101,11 @@ class AssignRoleCard extends Component {
                             });
                             successNotificationAnt(
                                 `Role '${role.label}' assigned on ${place} '${placeObject.name}'`,
+                                null,
                                 3
                             );
                             if (!successCount) {
-                                successNotificationAnt('Assignment Action Complete', 4);
+                                successNotificationAnt('Assignment Action Complete', 'Done', 4);
                                 this.setState({ assigning: false });
                                 this.props.allAssigned();
                             } else {
@@ -112,11 +113,7 @@ class AssignRoleCard extends Component {
                             }
                         })
                         .catch(error => {
-                            errorNotificationAnt(
-                                `Role '${
-                                    role.label
-                                }' either exists for the user or the required ${place} role does not exist.`
-                            );
+                            errorNotificationAnt(`Role '${role.label}' cannot be assigned.`);
                             this.setState({ assigning: count !== amountSelectedToAssign });
                             const invalidToken = apiErrorHandler(error);
                             invalidToken && this.props.invalidToken();

--- a/admin/src/pages/ManageUserRoles/UserCard.js
+++ b/admin/src/pages/ManageUserRoles/UserCard.js
@@ -69,15 +69,11 @@ class UserCard extends Component {
                             );
                         })
                         .catch(error => {
-                            let description =
-                                error.status === 403
-                                    ? `You do not have permission to remove role '${
-                                          userRole.role.label
-                                      }' from '${userRole[resource].name}'.`
-                                    : `Something went wrong. Cannot delete role '${
-                                          userRole.role.label
-                                      }' from '${userRole[resource].name}' for user`;
-                            errorNotificationAnt(description);
+                            errorNotificationAnt(
+                                `Something went wrong. Cannot delete role '${
+                                    userRole.role.label
+                                }' from '${userRole[resource].name}' for user`
+                            );
                             const invalidToken = apiErrorHandler(error);
                             invalidToken && this.props.invalidToken();
                         });

--- a/admin/src/pages/ManageUserRoles/UserCard.js
+++ b/admin/src/pages/ManageUserRoles/UserCard.js
@@ -10,7 +10,7 @@ import Divider from 'material-ui/Divider';
 import RaisedButton from 'material-ui/RaisedButton';
 
 import { styles } from '../../Theme';
-import { errorNotificationAnt, successNotificationAnt } from '../../utils';
+import { errorNotificationAnt, successNotificationAnt, apiErrorHandler } from '../../utils';
 import { checkRoleForDelete, deleteRole, invalidToken } from '../../actions/manageUserRoles';
 import restClient, { DELETE } from '../../restClient';
 import ConfirmDialog from './ConfirmDialog';
@@ -35,7 +35,6 @@ class UserCard extends Component {
         this.handleOpen = this.handleOpen.bind(this);
         this.handleClose = this.handleClose.bind(this);
         this.handleDelete = this.handleDelete.bind(this);
-        this.handleAPIError = this.handleAPIError.bind(this);
     }
 
     handleCheck(key) {
@@ -79,20 +78,13 @@ class UserCard extends Component {
                                           userRole.role.label
                                       }' from '${userRole[resource].name}' for user`;
                             errorNotificationAnt(description);
-                            this.handleAPIError(error);
+                            const invalidToken = apiErrorHandler(error);
+                            invalidToken && this.props.invalidToken();
                         });
                 }
                 return null;
             });
         }
-    }
-
-    handleAPIError(error) {
-        if (error.message === 'Token expired') {
-            localStorage.clear();
-            this.props.invalidToken();
-        }
-        console.error(error);
     }
 
     render() {

--- a/admin/src/pages/ManageUserRoles/UserSearch.js
+++ b/admin/src/pages/ManageUserRoles/UserSearch.js
@@ -6,7 +6,7 @@ import TextField from 'material-ui/TextField';
 import { reset, setSearchResults, selectUser, invalidToken } from '../../actions/manageUserRoles';
 import restClient, { GET_LIST } from '../../restClient';
 import InlineTable from '../../fields/InlineTable';
-import { makeIDMapping, getUntilDone, getUniqueIDs } from '../../utils';
+import { makeIDMapping, getUntilDone, getUniqueIDs, apiErrorHandler } from '../../utils';
 
 const mapStateToProps = state => ({
     manageUserRoles: state.manageUserRoles
@@ -94,7 +94,7 @@ class UserSearch extends Component {
                             this.props.selectUser(rows[0], { ...domainRoles, ...siteRoles });
                         })
                         .catch(error => {
-                            this.handleAPIError();
+                            this.handleAPIError(error);
                         });
                 })
                 .catch(error => {
@@ -104,11 +104,8 @@ class UserSearch extends Component {
     }
 
     handleAPIError(error) {
-        if (error.message === 'Token expired') {
-            localStorage.clear();
-            this.props.invalidToken();
-        }
-        console.error(error);
+        const invalidToken = apiErrorHandler(error);
+        invalidToken && this.props.invalidToken();
     }
 
     render() {

--- a/admin/src/pages/ManageUserRoles/index.js
+++ b/admin/src/pages/ManageUserRoles/index.js
@@ -19,7 +19,12 @@ import PermissionsStore from '../../auth/PermissionsStore';
 import restClient, { GET_LIST } from '../../restClient';
 import UserCard from './UserCard';
 import UserSearch from './UserSearch';
-import { makeIDMapping, getDomainAndSiteIds, getDomainsAndSites } from '../../utils';
+import {
+    makeIDMapping,
+    getDomainAndSiteIds,
+    getDomainsAndSites,
+    apiErrorHandler
+} from '../../utils';
 
 const mapStateToProps = state => ({
     manageUserRoles: state.manageUserRoles
@@ -98,11 +103,8 @@ class ManageUserRoles extends Component {
     }
 
     handleAPIError(error) {
-        if (error.message === 'Token expired') {
-            localStorage.clear();
-            this.props.invalidToken();
-        }
-        console.error(error);
+        const invalidToken = apiErrorHandler(error);
+        invalidToken && this.props.invalidToken();
     }
 
     render() {

--- a/admin/src/utils.js
+++ b/admin/src/utils.js
@@ -35,9 +35,19 @@ export const getDomainsAndSites = ids => {
 
 export const toBool = thing => !!thing;
 
-export const successNotificationAnt = (description, duration = 3) => {
+export const apiErrorHandler = error => {
+    const message = error.body.message || error.body.error;
+    errorNotificationAnt(message, 'Error');
+    if (error.message === 'Token expired') {
+        localStorage.clear();
+        return true;
+    }
+    return false;
+};
+
+export const successNotificationAnt = (description, heading = null, duration = 3) => {
     notification.success({
-        message: 'Success!',
+        message: heading || 'Success!',
         description,
         duration,
         style: {
@@ -48,9 +58,9 @@ export const successNotificationAnt = (description, duration = 3) => {
     });
 };
 
-export const errorNotificationAnt = (description, duration = 0) => {
+export const errorNotificationAnt = (description, heading = null, duration = 0) => {
     notification.error({
-        message: 'Oh No!',
+        message: heading || 'Oh No!',
         description,
         duration,
         style: {


### PR DESCRIPTION
**Background:** Error responses from the Management Layer have been made to be JSONReponses with either a `message` or `error` key in the response containing the reason for the error from a service down the line or the Management Layer API itself. 

**What was done:** All instances of handling an API error have been alter to use a general utility function that handles an API error. This function also returns if the token has expired or not for the appropriate action to be carried out if so. Some of the current messages were redone to work with the new error message from the response.