### PR TITLE
Added purge expired invites button to Invitations page.

### DIFF
--- a/admin/src/customActions/Invitation.js
+++ b/admin/src/customActions/Invitation.js
@@ -2,14 +2,67 @@ import React, { Component } from 'react';
 import { CardActions } from 'material-ui/Card';
 import FlatButton from 'material-ui/FlatButton';
 import SendIcon from 'material-ui/svg-icons/content/send';
-import { DeleteButton, ListButton, RefreshButton, EditButton } from 'admin-on-rest';
+import PurgeIcon from 'material-ui/svg-icons/social/whatshot';
+import { CreateButton, DeleteButton, ListButton, RefreshButton, EditButton } from 'admin-on-rest';
 
 import { styles } from '../Theme';
-import { successNotificationAnt, errorNotificationAnt } from '../utils';
+import { successNotificationAnt, errorNotificationAnt, apiErrorHandler } from '../utils';
+import { httpClient } from '../restClient';
 
 const timezoneOffset = new Date().getTimezoneOffset();
 
-class InvitationShowActions extends Component {
+export class InvitationListActions extends Component {
+    purgeExpiredInvitations() {
+        httpClient(
+            `${
+                process.env.REACT_APP_MANAGEMENT_LAYER
+            }/invitations/purge/expired?synchronous_mode=true`
+        )
+            .then(response => {
+                successNotificationAnt(
+                    'Expired Invitations are being purged. Refresh to see any changes that have occured.'
+                );
+            })
+            .catch(error => {
+                errorNotificationAnt('Purging of invites was not initialized.');
+                apiErrorHandler(error);
+            });
+    }
+
+    render() {
+        const {
+            resource,
+            filters,
+            displayedFilters,
+            filterValues,
+            basePath,
+            showFilter
+        } = this.props;
+        return (
+            <CardActions style={styles.cardAction}>
+                {filters &&
+                    React.cloneElement(filters, {
+                        resource,
+                        showFilter,
+                        displayedFilters,
+                        filterValues,
+                        context: 'button'
+                    })}
+                <CreateButton basePath={basePath} />
+                <RefreshButton />
+                {/* Add your custom actions */}
+                <FlatButton
+                    primary
+                    icon={<PurgeIcon />}
+                    label="Purge Expired Invites"
+                    onClick={this.purgeExpiredInvitations}
+                />
+            </CardActions>
+        );
+    }
+}
+
+export class InvitationShowActions extends Component {
     constructor(props) {
         super(props);
         this.inviteNotExpired = this.inviteNotExpired.bind(this);
@@ -28,21 +81,13 @@ class InvitationShowActions extends Component {
 
     sendInvite() {
         const data = this.props.data;
-        const id_token = localStorage.getItem('id_token');
-        const permissions = JSON.parse(localStorage.getItem('permissions'));
-        fetch(`${process.env.REACT_APP_MANAGEMENT_LAYER}/invitations/${data.id}/send`, {
-            method: 'GET',
-            headers: {
-                'Authorization': `Bearer ${id_token}`,
-                'X-GE-Portal-Context': permissions.currentContext.key
-            }
-        })
+        httpClient(`${process.env.REACT_APP_MANAGEMENT_LAYER}/invitations/${data.id}/send`)
             .then(response => {
                 successNotificationAnt('An invitation email was successfully queued for sending.');
             })
             .catch(error => {
-                console.error(error);
                 errorNotificationAnt('Invite not sent.');
+                apiErrorHandler(error);
             });
     }
 
@@ -67,5 +112,3 @@ class InvitationShowActions extends Component {
         );
     }
 }
-
-export default InvitationShowActions;

--- a/admin/src/customActions/Invitation.js
+++ b/admin/src/customActions/Invitation.js
@@ -50,7 +50,6 @@ export class InvitationListActions extends Component {
                     })}
                 <CreateButton basePath={basePath} />
                 <RefreshButton />
-                {/* Add your custom actions */}
                 <FlatButton
                     primary
                     icon={<PurgeIcon />}
@@ -99,7 +98,6 @@ export class InvitationShowActions extends Component {
                 <ListButton basePath={basePath} />
                 <DeleteButton basePath={basePath} record={data} />
                 <RefreshButton />
-                {/* Custom Actions */}
                 {this.inviteNotExpired() && (
                     <FlatButton
                         primary

--- a/admin/src/resources/Invitation.js
+++ b/admin/src/resources/Invitation.js
@@ -27,7 +27,7 @@ import PermissionsStore from '../auth/PermissionsStore';
 import EmptyField from '../fields/EmptyField';
 import DateTimeInput from 'aor-datetime-input';
 import InvitationFilter from '../filters/InvitationFilter';
-import InvitationShowActions from '../customActions/Invitation';
+import { InvitationListActions, InvitationShowActions } from '../customActions/Invitation';
 
 const timezoneOffset = new Date().getTimezoneOffset();
 
@@ -71,7 +71,12 @@ const validationEditInvitation = values => {
 };
 
 export const InvitationList = props => (
-    <List {...props} title="Invitation List" filters={<InvitationFilter />}>
+    <List
+        {...props}
+        title="Invitation List"
+        actions={<InvitationListActions />}
+        filters={<InvitationFilter />}
+    >
         <Datagrid bodyOptions={{ showRowHover: true }}>
             <TextField source="id" sortable={false} />
             {PermissionsStore.getResourcePermission('users', 'list') ? (

--- a/admin/src/restClient.js
+++ b/admin/src/restClient.js
@@ -291,7 +291,7 @@ const restClient = (apiUrl, httpClient = fetchUtils.fetchJson) => {
     };
 };
 
-const httpClient = (url, options = {}) => {
+export const httpClient = (url, options = {}) => {
     if (!options.headers) {
         options.headers = new Headers({ Accept: 'application/json' });
     }


### PR DESCRIPTION
**Background:** The ability to purge expired invites was added to the Management Layer API. 

**What was done:** A custom action was created (as per https://marmelab.com/admin-on-rest/List.html#actions) and added to the `invitation_list` page. This will fire off an action to purge all expired invitations. 