### PR TITLE
View deleted users and go green

### DIFF
--- a/admin/package.json
+++ b/admin/package.json
@@ -19,6 +19,6 @@
     "eject": "react-scripts eject"
   },
   "devDependencies": {
-    "prettier": "1.13.7"
+    "prettier": "^1.14.0"
   }
 }

--- a/admin/src/App.js
+++ b/admin/src/App.js
@@ -407,18 +407,18 @@ const App = () => (
                     name="deletedusers"
                     list={DeletedUserList}
                     create={
-                        PermissionsStore.getResourcePermission('deleteduser', 'create')
+                        PermissionsStore.getResourcePermission('deletedusers', 'create')
                             ? DeletedUserCreate
                             : null
                     }
                     remove={
-                        PermissionsStore.getResourcePermission('deleteduser', 'remove')
+                        PermissionsStore.getResourcePermission('deletedusers', 'remove')
                             ? Delete
                             : null
                     }
                     show={DeletedUserShow}
                     edit={
-                        PermissionsStore.getResourcePermission('deleteduser', 'edit')
+                        PermissionsStore.getResourcePermission('deletedusers', 'edit')
                             ? DeletedUserEdit
                             : null
                     }
@@ -429,18 +429,18 @@ const App = () => (
                     name="deletedusersites"
                     list={DeletedUserSiteList}
                     create={
-                        PermissionsStore.getResourcePermission('deletedusersite', 'create')
+                        PermissionsStore.getResourcePermission('deletedusersites', 'create')
                             ? DeletedUserSiteCreate
                             : null
                     }
                     remove={
-                        PermissionsStore.getResourcePermission('deletedusersite', 'remove')
+                        PermissionsStore.getResourcePermission('deletedusersites', 'remove')
                             ? Delete
                             : null
                     }
                     show={DeletedUserSiteShow}
                     edit={
-                        PermissionsStore.getResourcePermission('deletedusersite', 'edit')
+                        PermissionsStore.getResourcePermission('deletedusersites', 'edit')
                             ? DeletedUserSiteEdit
                             : null
                     }

--- a/admin/src/Menu.js
+++ b/admin/src/Menu.js
@@ -23,7 +23,7 @@ import CategoryIcon from 'material-ui/svg-icons/action/account-balance';
 import ContextSwitchIcon from 'material-ui/svg-icons/communication/swap-calls';
 import DeletedUserIcon from 'material-ui/svg-icons/av/recent-actors';
 import DeletedSiteIcon from 'material-ui/svg-icons/communication/location-off';
-import { pink300 } from 'material-ui/styles/colors';
+import { green300 } from 'material-ui/styles/colors';
 
 import PermissionsStore from './auth/PermissionsStore';
 import { titleCase, notEmptyObject } from './utils';
@@ -68,7 +68,7 @@ const Menu = ({ resources, onMenuTap, logout }) => {
                             .join(' ')
                     )}`}
                     onClick={onMenuTap}
-                    leftIcon={<ContextSwitchIcon color={pink300} />}
+                    leftIcon={<ContextSwitchIcon color={green300} />}
                 />
             ) : null}
             {resources

--- a/admin/src/Menu.js
+++ b/admin/src/Menu.js
@@ -23,7 +23,7 @@ import CategoryIcon from 'material-ui/svg-icons/action/account-balance';
 import ContextSwitchIcon from 'material-ui/svg-icons/communication/swap-calls';
 import DeletedUserIcon from 'material-ui/svg-icons/av/recent-actors';
 import DeletedSiteIcon from 'material-ui/svg-icons/communication/location-off';
-import { green300 } from 'material-ui/styles/colors';
+import { teal500 } from 'material-ui/styles/colors';
 
 import PermissionsStore from './auth/PermissionsStore';
 import { titleCase, notEmptyObject } from './utils';
@@ -68,7 +68,7 @@ const Menu = ({ resources, onMenuTap, logout }) => {
                             .join(' ')
                     )}`}
                     onClick={onMenuTap}
-                    leftIcon={<ContextSwitchIcon color={green300} />}
+                    leftIcon={<ContextSwitchIcon color={teal500} />}
                 />
             ) : null}
             {resources

--- a/admin/src/Theme.js
+++ b/admin/src/Theme.js
@@ -1,10 +1,10 @@
 import getMuiTheme from 'material-ui/styles/getMuiTheme';
-import { green500, green300 } from 'material-ui/styles/colors';
+import { teal800, teal500 } from 'material-ui/styles/colors';
 
 export const muiTheme = getMuiTheme({
     palette: {
-        primary1Color: green500,
-        accent1Color: green300
+        primary1Color: teal500,  // cobusc: I swapped primary and accent1 colours
+        accent1Color: teal800
     }
 });
 

--- a/admin/src/Theme.js
+++ b/admin/src/Theme.js
@@ -1,10 +1,10 @@
 import getMuiTheme from 'material-ui/styles/getMuiTheme';
-import { pink500, pink300 } from 'material-ui/styles/colors';
+import { green500, green300 } from 'material-ui/styles/colors';
 
 export const muiTheme = getMuiTheme({
     palette: {
-        primary1Color: pink500,
-        accent1Color: pink300
+        primary1Color: green500,
+        accent1Color: green300
     }
 });
 

--- a/admin/src/auth/authLogin.js
+++ b/admin/src/auth/authLogin.js
@@ -6,7 +6,7 @@ import { Card, CardActions } from 'material-ui/Card';
 import Avatar from 'material-ui/Avatar';
 import RaisedButton from 'material-ui/RaisedButton';
 import LockIcon from 'material-ui/svg-icons/action/lock-outline';
-import { pink300, pink500 } from 'material-ui/styles/colors';
+import { green300, green500 } from 'material-ui/styles/colors';
 
 import { userLogin } from 'admin-on-rest';
 
@@ -53,10 +53,10 @@ class AuthLoginPage extends Component {
         const loginUrl = `${OIDC_PROVIDER_URL}?${queryString}`;
         return (
             <MuiThemeProvider muiTheme={muiTheme}>
-                <div style={{ ...styles.main, backgroundColor: pink500 }}>
+                <div style={{ ...styles.main, backgroundColor: green500 }}>
                     <Card style={styles.card}>
                         <div style={styles.avatar}>
-                            <Avatar backgroundColor={pink300} icon={<LockIcon />} size={60} />
+                            <Avatar backgroundColor={green300} icon={<LockIcon />} size={60} />
                         </div>
                         <CardActions>
                             <p style={styles.avatar}>Login with Girl Effect OIDC Provider</p>

--- a/admin/src/auth/authLogin.js
+++ b/admin/src/auth/authLogin.js
@@ -6,7 +6,7 @@ import { Card, CardActions } from 'material-ui/Card';
 import Avatar from 'material-ui/Avatar';
 import RaisedButton from 'material-ui/RaisedButton';
 import LockIcon from 'material-ui/svg-icons/action/lock-outline';
-import { green300, green500 } from 'material-ui/styles/colors';
+import { teal500, teal800 } from 'material-ui/styles/colors';
 
 import { userLogin } from 'admin-on-rest';
 
@@ -53,10 +53,10 @@ class AuthLoginPage extends Component {
         const loginUrl = `${OIDC_PROVIDER_URL}?${queryString}`;
         return (
             <MuiThemeProvider muiTheme={muiTheme}>
-                <div style={{ ...styles.main, backgroundColor: green500 }}>
+                <div style={{ ...styles.main, backgroundColor: teal800 }}>
                     <Card style={styles.card}>
                         <div style={styles.avatar}>
-                            <Avatar backgroundColor={green300} icon={<LockIcon />} size={60} />
+                            <Avatar backgroundColor={teal500} icon={<LockIcon />} size={60} />
                         </div>
                         <CardActions>
                             <p style={styles.avatar}>Login with Girl Effect OIDC Provider</p>

--- a/admin/src/customActions/User.js
+++ b/admin/src/customActions/User.js
@@ -28,7 +28,7 @@ class UserShowActions extends Component {
     }
 
     handleDelete() {
-        const { basePath, data } = this.props;
+        const { data } = this.props;
         httpClient(`${process.env.REACT_APP_MANAGEMENT_LAYER}/request_user_deletion`,
                    {
                        method: "POST",

--- a/admin/src/pages/ContextChanger.js
+++ b/admin/src/pages/ContextChanger.js
@@ -8,7 +8,7 @@ import CardText from 'material-ui/Card/CardText';
 import CircularProgress from 'material-ui/CircularProgress';
 import FlatButton from 'material-ui/FlatButton';
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
-import { green500 } from 'material-ui/styles/colors';
+import { teal800 } from 'material-ui/styles/colors';
 import RaisedButton from 'material-ui/RaisedButton';
 
 import { muiTheme, styles } from '../Theme';
@@ -98,7 +98,7 @@ class ContextChanger extends Component {
             <Redirect push to="/" />
         ) : (
             <MuiThemeProvider muiTheme={muiTheme}>
-                <div style={{ ...styles.main, backgroundColor: green500 }}>
+                <div style={{ ...styles.main, backgroundColor: teal800 }}>
                     <Card style={styles.cardCentered}>
                         {changing ? (
                             <CardText>

--- a/admin/src/pages/ContextChanger.js
+++ b/admin/src/pages/ContextChanger.js
@@ -8,7 +8,7 @@ import CardText from 'material-ui/Card/CardText';
 import CircularProgress from 'material-ui/CircularProgress';
 import FlatButton from 'material-ui/FlatButton';
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
-import { pink500 } from 'material-ui/styles/colors';
+import { green500 } from 'material-ui/styles/colors';
 import RaisedButton from 'material-ui/RaisedButton';
 
 import { muiTheme, styles } from '../Theme';
@@ -98,7 +98,7 @@ class ContextChanger extends Component {
             <Redirect push to="/" />
         ) : (
             <MuiThemeProvider muiTheme={muiTheme}>
-                <div style={{ ...styles.main, backgroundColor: pink500 }}>
+                <div style={{ ...styles.main, backgroundColor: green500 }}>
                     <Card style={styles.cardCentered}>
                         {changing ? (
                             <CardText>

--- a/admin/src/pages/WaitingPage.js
+++ b/admin/src/pages/WaitingPage.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { pink500 } from 'material-ui/styles/colors';
+import { green500 } from 'material-ui/styles/colors';
 import WaitIcon from 'material-ui/svg-icons/action/update';
 import LinearProgress from 'material-ui/LinearProgress';
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
@@ -8,7 +8,7 @@ import { muiTheme, styles } from '../Theme';
 
 const WaitingPage = () => (
     <MuiThemeProvider muiTheme={muiTheme}>
-        <div style={{ ...styles.main, backgroundColor: pink500 }}>
+        <div style={{ ...styles.main, backgroundColor: green500 }}>
             <WaitIcon style={styles.waitIcon} />
             <LinearProgress mode="indeterminate" style={styles.linearProgress} />
         </div>

--- a/admin/src/pages/WaitingPage.js
+++ b/admin/src/pages/WaitingPage.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { green500 } from 'material-ui/styles/colors';
+import { teal800 } from 'material-ui/styles/colors';
 import WaitIcon from 'material-ui/svg-icons/action/update';
 import LinearProgress from 'material-ui/LinearProgress';
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
@@ -8,7 +8,7 @@ import { muiTheme, styles } from '../Theme';
 
 const WaitingPage = () => (
     <MuiThemeProvider muiTheme={muiTheme}>
-        <div style={{ ...styles.main, backgroundColor: green500 }}>
+        <div style={{ ...styles.main, backgroundColor: teal800 }}>
             <WaitIcon style={styles.waitIcon} />
             <LinearProgress mode="indeterminate" style={styles.linearProgress} />
         </div>

--- a/admin/src/resources/DeletedUser.js
+++ b/admin/src/resources/DeletedUser.js
@@ -14,6 +14,8 @@ import {
     TextInput,
     Show,
     SimpleShowLayout,
+    ReferenceManyField,
+    NumberField,
     Edit,
     DeleteButton,
     EditButton,
@@ -86,9 +88,9 @@ export const DeletedUserList = props => (
             ) : (
                 <EmptyField />
             )}
-            {PermissionsStore.getResourcePermission('deleteduser', 'edit') ? <EditButton /> : null}
+            {PermissionsStore.getResourcePermission('deletedusers', 'edit') ? <EditButton /> : null}
             <ShowButton />
-            {PermissionsStore.getResourcePermission('deleteduser', 'remove') ? (
+            {PermissionsStore.getResourcePermission('deletedusers', 'remove') ? (
                 <DeleteButton />
             ) : null}
         </Datagrid>
@@ -131,6 +133,33 @@ export const DeletedUserShow = props => (
             ) : (
                 <EmptyField />
             )}
+            {PermissionsStore.getResourcePermission('deletedusersites', 'list') ? (
+                <ReferenceManyField
+                    label="Sites which the user visited"
+                    reference="deletedusersites"
+                    target="deleted_user_id"
+                >
+                    <Datagrid bodyOptions={{ showRowHover: true }}>
+                        <ReferenceField
+                            label="Site"
+                            source="site_id"
+                            reference="sites"
+                            linkType="show"
+                            allowEmpty
+                        >
+                            <NumberField source="name" />
+                        </ReferenceField>
+                        <DateField source="created_at" />
+                        <DateField source="updated_at" />
+                        <DateField source="deletion_requested_at" />
+                        <TextField source="deletion_requested_via" />
+                        <DateField source="deletion_confirmed_at" />
+                        <TextField source="deletion_confirmed_via" />
+                    </Datagrid>
+                </ReferenceManyField>
+            ) : (
+                <EmptyField />
+            )}
         </SimpleShowLayout>
     </Show>
 );
@@ -143,6 +172,33 @@ export const DeletedUserEdit = props => (
             <TextInput source="msisdn" />
             <TextInput source="reason" />
             <DateTimeInput source="deleted_at" format={dateTimeFormatter} parse={dateTimeParser} />
+            {PermissionsStore.getResourcePermission('deletedusersites', 'list') ? (
+                <ReferenceManyField
+                    label="Sites which the user visited"
+                    reference="deletedusersites"
+                    target="deleted_user_id"
+                >
+                    <Datagrid bodyOptions={{ showRowHover: true }}>
+                        <ReferenceField
+                            label="Site"
+                            source="site_id"
+                            reference="sites"
+                            linkType="show"
+                            allowEmpty
+                        >
+                            <NumberField source="name" />
+                        </ReferenceField>
+                        <DateField source="created_at" />
+                        <DateField source="updated_at" />
+                        <DateField source="deletion_requested_at" />
+                        <TextField source="deletion_requested_via" />
+                        <DateField source="deletion_confirmed_at" />
+                        <TextField source="deletion_confirmed_via" />
+                    </Datagrid>
+                </ReferenceManyField>
+            ) : (
+                <EmptyField />
+            )}
         </SimpleForm>
     </Edit>
 );

--- a/admin/src/resources/DeletedUserSite.js
+++ b/admin/src/resources/DeletedUserSite.js
@@ -64,16 +64,16 @@ const validationEditDeletedUserSite = values => {
 export const DeletedUserSiteList = props => (
     <List {...props} title="DeletedUserSite List" filters={<DeletedUserSiteFilter />}>
         <Datagrid bodyOptions={{ showRowHover: true }}>
-            {PermissionsStore.getResourcePermission('deleted_users', 'list') ? (
+            {PermissionsStore.getResourcePermission('deletedusers', 'list') ? (
                 <ReferenceField
-                    label="Deleted_User"
+                    label="Deleted User"
                     source="deleted_user_id"
-                    reference="deleted_users"
+                    reference="deletedusers"
                     sortable={false}
                     linkType="show"
                     allowEmpty
                 >
-                    <TextField source="" />
+                    <TextField source="username" />
                 </ReferenceField>
             ) : (
                 <EmptyField />
@@ -87,7 +87,7 @@ export const DeletedUserSiteList = props => (
                     linkType="show"
                     allowEmpty
                 >
-                    <NumberField source="" />
+                    <NumberField source="name" />
                 </ReferenceField>
             ) : (
                 <EmptyField />
@@ -98,11 +98,11 @@ export const DeletedUserSiteList = props => (
             <TextField source="deletion_requested_via" sortable={false} />
             <DateField source="deletion_confirmed_at" sortable={false} />
             <TextField source="deletion_confirmed_via" sortable={false} />
-            {PermissionsStore.getResourcePermission('deletedusersite', 'edit') ? (
+            {PermissionsStore.getResourcePermission('deletedusersites', 'edit') ? (
                 <EditButton />
             ) : null}
             <ShowButton />
-            {PermissionsStore.getResourcePermission('deletedusersite', 'remove') ? (
+            {PermissionsStore.getResourcePermission('deletedusersites', 'remove') ? (
                 <DeleteButton />
             ) : null}
         </Datagrid>
@@ -112,11 +112,11 @@ export const DeletedUserSiteList = props => (
 export const DeletedUserSiteCreate = props => (
     <Create {...props} title="DeletedUserSite Create">
         <SimpleForm validate={validationCreateDeletedUserSite}>
-            {PermissionsStore.getResourcePermission('deleted_users', 'list') && (
+            {PermissionsStore.getResourcePermission('deletedusers', 'list') && (
                 <ReferenceInput
                     label="Deleted_User"
                     source="deleted_user_id"
-                    reference="deleted_users"
+                    reference="deletedusers"
                     perPage={0}
                     allowEmpty
                 >
@@ -153,15 +153,15 @@ export const DeletedUserSiteCreate = props => (
 export const DeletedUserSiteShow = props => (
     <Show {...props} title="DeletedUserSite Show">
         <SimpleShowLayout>
-            {PermissionsStore.getResourcePermission('deleted_users', 'list') ? (
+            {PermissionsStore.getResourcePermission('deletedusers', 'list') ? (
                 <ReferenceField
-                    label="Deleted_User"
+                    label="Deleted User"
                     source="deleted_user_id"
-                    reference="deleted_users"
+                    reference="deletedusers"
                     linkType="show"
                     allowEmpty
                 >
-                    <TextField source="" />
+                    <TextField source="username" />
                 </ReferenceField>
             ) : (
                 <EmptyField />
@@ -174,7 +174,7 @@ export const DeletedUserSiteShow = props => (
                     linkType="show"
                     allowEmpty
                 >
-                    <NumberField source="" />
+                    <NumberField source="name" />
                 </ReferenceField>
             ) : (
                 <EmptyField />

--- a/admin/src/resources/DeletedUserSite.js
+++ b/admin/src/resources/DeletedUserSite.js
@@ -23,8 +23,8 @@ import {
     ShowButton
 } from 'admin-on-rest';
 import PermissionsStore from '../auth/PermissionsStore';
-import DateTimeInput from 'aor-datetime-input';
 import EmptyField from '../fields/EmptyField';
+import DateTimeInput from 'aor-datetime-input';
 import DeletedUserSiteFilter from '../filters/DeletedUserSiteFilter';
 const timezoneOffset = new Date().getTimezoneOffset();
 
@@ -114,13 +114,13 @@ export const DeletedUserSiteCreate = props => (
         <SimpleForm validate={validationCreateDeletedUserSite}>
             {PermissionsStore.getResourcePermission('deletedusers', 'list') && (
                 <ReferenceInput
-                    label="Deleted_User"
+                    label="Deleted User"
                     source="deleted_user_id"
                     reference="deletedusers"
                     perPage={0}
                     allowEmpty
                 >
-                    <SelectInput optionText="" />
+                    <SelectInput optionText="username" />
                 </ReferenceInput>
             )}
             {PermissionsStore.getResourcePermission('sites', 'list') && (
@@ -131,7 +131,7 @@ export const DeletedUserSiteCreate = props => (
                     perPage={0}
                     allowEmpty
                 >
-                    <SelectInput optionText="" />
+                    <SelectInput optionText="name" />
                 </ReferenceInput>
             )}
             <DateTimeInput

--- a/admin/src/restClient.js
+++ b/admin/src/restClient.js
@@ -18,6 +18,7 @@ export const DELETE = 'DELETE';
 
 const COMPOSITE_KEY_RESOURSES = {
     domainroles: ['domain_id', 'role_id'],
+    deletedusersites: ['deleted_user_id', 'site_id'],
     invitationdomainroles: ['invitation_id', 'domain_id', 'role_id'],
     invitationsiteroles: ['invitation_id', 'site_id', 'role_id'],
     roleresourcepermissions: ['role_id', 'resource_id', 'permission_id'],

--- a/admin/yarn.lock
+++ b/admin/yarn.lock
@@ -5345,9 +5345,9 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
-prettier@1.13.7:
-  version "1.13.7"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.13.7.tgz#850f3b8af784a49a6ea2d2eaa7ed1428a34b7281"
+prettier@^1.14.0:
+  version "1.14.0"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.14.0.tgz#847c235522035fd988100f1f43cf20a7d24f9372"
 
 pretty-bytes@^4.0.2:
   version "4.0.2"

--- a/swagger/management_layer.yml
+++ b/swagger/management_layer.yml
@@ -1340,8 +1340,14 @@ definitions:
       deleted_user_id:
         type: string
         format: uuid
+        x-related-info:
+          model: deleted_user
+          label: username
       site_id:
         type: integer
+        x-related-info:
+          model: site
+          label: name
       created_at:
         type: string
         format: date-time
@@ -1409,14 +1415,10 @@ definitions:
       user_id:
         type: string
         format: uuid
-      deleter_id:
-        type: string
-        format: uuid
       reason:
         type: string
     required:
       - user_id
-      - deleter_id
       - reason
 
   client:
@@ -4475,3 +4477,17 @@ x-detail-page-definitions:
         - updated_at
     sortable_fields:
       - id
+  deleteduser:
+    inlines:
+    - model: deleted_user_site
+      label: Sites which the user visited
+      key: deleted_user_id
+      fields:
+      - site_id
+      - deletion_requested_at
+      - deletion_requested_via
+      - deletion_confirmed_at
+      - deletion_confirmed_via
+      - created_at
+      - updated_at
+

--- a/swagger/management_layer.yml
+++ b/swagger/management_layer.yml
@@ -1378,8 +1378,14 @@ definitions:
       deleted_user_id:
         type: string
         format: uuid
+        x-related-info:
+          model: deleted_user
+          label: username
       site_id:
         type: integer
+        x-related-info:
+          model: site
+          label: name
       deletion_requested_at:
         type: string
         format: date-time


### PR DESCRIPTION
# Background
This PR caters for two tickets:
## GEINFRA-23: View deleted users
I added inline definitions for `deleted_user_sites` and regenerated code.
## GEINFRA-192: Change pink to green colour
The exact colour (`#2f6165`) is not defined in the Material UI palette, so I used `teal800`.