### PR TITLE
Added Logout leaving page and custom logout flow. Improves UX.

### DIFF
--- a/admin/src/Menu.js
+++ b/admin/src/Menu.js
@@ -28,6 +28,7 @@ import { teal500 } from 'material-ui/styles/colors';
 import PermissionsStore from './auth/PermissionsStore';
 import { titleCase, notEmptyObject } from './utils';
 import { TITLES, PERMISSIONS } from './constants';
+import Logout from './customActions/Logout';
 
 const ICONS = {
     domains: <DomainIcon />,
@@ -54,7 +55,7 @@ const ICONS = {
     users: <PeopleIcon />
 };
 
-const Menu = ({ resources, onMenuTap, logout }) => {
+const Menu = ({ resources, onMenuTap }) => {
     const contexts = PermissionsStore.getAllContexts();
     const showContextSwitcher = Object.keys(contexts).length > 1;
     return (
@@ -94,7 +95,7 @@ const Menu = ({ resources, onMenuTap, logout }) => {
                     leftIcon={<ManageIcon />}
                 />
             ) : null}
-            {logout}
+            <Logout />
         </div>
     );
 };

--- a/admin/src/auth/authClient.js
+++ b/admin/src/auth/authClient.js
@@ -1,18 +1,7 @@
-import { AUTH_LOGOUT, AUTH_CHECK, AUTH_ERROR } from 'admin-on-rest';
-import { generateQueryString, apiErrorHandler } from '../utils';
+import { AUTH_CHECK, AUTH_ERROR } from 'admin-on-rest';
+import { apiErrorHandler } from '../utils';
 
 export default (type, params) => {
-    if (type === AUTH_LOGOUT) {
-        if (localStorage.getItem('id_token')) {
-            const logoutQueryString = generateQueryString({
-                id_token_hint: localStorage.getItem('id_token'),
-                post_logout_redirect_uri: process.env.REACT_APP_PORTAL_URL
-            });
-            localStorage.clear();
-            let logoutURL = `${process.env.REACT_APP_LOGOUT_URL}?${logoutQueryString}`;
-            window.location.href = logoutURL;
-        }
-    }
     if (type === AUTH_ERROR) {
         const invalidToken = apiErrorHandler(params);
         if (invalidToken) {

--- a/admin/src/customActions/Logout.js
+++ b/admin/src/customActions/Logout.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import { push } from 'react-router-redux';
+
+import MenuItem from 'material-ui/MenuItem';
+import ExitIcon from 'material-ui/svg-icons/action/power-settings-new';
+
+import { generateQueryString } from '../utils';
+
+const mapDispatchToProps = dispatch => ({
+    logout: () => {
+        dispatch(push('/leaving'));
+        if (localStorage.getItem('id_token')) {
+            const logoutQueryString = generateQueryString({
+                id_token_hint: localStorage.getItem('id_token'),
+                post_logout_redirect_uri: process.env.REACT_APP_PORTAL_URL
+            });
+            localStorage.clear();
+            let logoutURL = `${process.env.REACT_APP_LOGOUT_URL}?${logoutQueryString}`;
+            window.location.href = logoutURL;
+        }
+    }
+});
+
+const Logout = ({ logout }) => (
+    <MenuItem className="logout" leftIcon={<ExitIcon />} primaryText="Logout" onClick={logout} />
+);
+
+export default connect(
+    null,
+    mapDispatchToProps
+)(Logout);

--- a/admin/src/customRoutes.js
+++ b/admin/src/customRoutes.js
@@ -4,9 +4,11 @@ import { Route } from 'react-router-dom';
 import OIDCCallback from './auth/OIDCCallback';
 import ManageUserRoles from './pages/ManageUserRoles';
 import ContextChanger from './pages/ContextChanger';
+import LeavingPage from './pages/LeavingPage';
 
 export default [
     <Route exact path="/oidc/callback" component={OIDCCallback} noLayout />,
     <Route exact path="/contextchanger" component={ContextChanger} noLayout />,
+    <Route exact path="/leaving" component={LeavingPage} noLayout />,
     <Route exact path="/manageuserroles" component={ManageUserRoles} />
 ];

--- a/admin/src/pages/LeavingPage.js
+++ b/admin/src/pages/LeavingPage.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import LeavingIcon from 'material-ui/svg-icons/maps/flight';
+
+import WaitingPage from './WaitingPage';
+
+const LeavingPage = () => {
+	return <WaitingPage icon={LeavingIcon} />
+}
+
+export default LeavingPage;

--- a/admin/src/pages/WaitingPage.js
+++ b/admin/src/pages/WaitingPage.js
@@ -6,13 +6,16 @@ import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 
 import { muiTheme, styles } from '../Theme';
 
-const WaitingPage = () => (
-    <MuiThemeProvider muiTheme={muiTheme}>
-        <div style={{ ...styles.main, backgroundColor: teal800 }}>
-            <WaitIcon style={styles.waitIcon} />
-            <LinearProgress mode="indeterminate" style={styles.linearProgress} />
-        </div>
-    </MuiThemeProvider>
-);
+const WaitingPage = ({ icon }) => {
+    const PageIcon = icon || WaitIcon;
+    return (
+        <MuiThemeProvider muiTheme={muiTheme}>
+            <div style={{ ...styles.main, backgroundColor: teal800 }}>
+                <PageIcon style={styles.waitIcon} />
+                <LinearProgress mode="indeterminate" style={styles.linearProgress} />
+            </div>
+        </MuiThemeProvider>
+    );
+};
 
 export default WaitingPage;


### PR DESCRIPTION
**Background:** The logout button clears the localstorage which causes the page to redirect to the login page and the logout url on the Authentication Service is then hit to logout from their Auth Session. However on QA the logout url on the Auth service is hit after a few seconds. The user is thus left in a limbo state that maybe confusing. 

**What was done:** A custom logout button was added to hit a leaving page whist the Auth service logout happens. Then when logged out the Auth service will redirect to the correct login page.