### PR TITLE
Feature/geinfra 142

### DIFF
--- a/admin/package.json
+++ b/admin/package.json
@@ -6,6 +6,7 @@
     "admin-on-rest": "^1.3.4",
     "antd": "^3.6.4",
     "aor-datetime-input": "^1.0.6",
+    "react-blockies": "^1.3.0",
     "jwt-decode": "^2.2.0",
     "query-string": "^6.0.0",
     "react": "^16.2.0",

--- a/admin/src/fields/IndeticonField.js
+++ b/admin/src/fields/IndeticonField.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import Blockie from 'react-blockies';
+
+const IdenticonField = ({ source, record = {}, size = 10 }) => {
+    const value = record[source];
+    return (
+        <span title={value}>
+            <Blockie
+                seed={value}
+                size={size}
+                color="#009688"
+                bgColor="#f5f5f5"
+                spotColor="#f5f5f5"
+            />
+        </span>
+    );
+};
+
+export default IdenticonField;

--- a/admin/src/resources/AdminNote.js
+++ b/admin/src/resources/AdminNote.js
@@ -9,6 +9,8 @@ import {
     ReferenceField,
     TextField,
     DateField,
+    Responsive,
+    SimpleList,
     SimpleForm,
     Create,
     ReferenceInput,
@@ -44,45 +46,52 @@ const validationEditAdminNote = values => {
 
 export const AdminNoteList = props => (
     <List {...props} title="AdminNote List" filters={<AdminNoteFilter />}>
-        <EditableDatagrid bodyOptions={{ showRowHover: true }}>
-            <NumberField source="id" sortable={false} />
-            {PermissionsStore.getResourcePermission('users', 'list') ? (
-                <ReferenceField
-                    label="User"
-                    source="user_id"
-                    reference="users"
-                    sortable={false}
-                    linkType="show"
-                    allowEmpty
-                >
-                    <TextField source="username" />
-                </ReferenceField>
-            ) : (
-                <EmptyField />
-            )}
-            {PermissionsStore.getResourcePermission('users', 'list') ? (
-                <ReferenceField
-                    label="User"
-                    source="creator_id"
-                    reference="users"
-                    sortable={false}
-                    linkType="show"
-                    allowEmpty
-                >
-                    <TextField source="username" />
-                </ReferenceField>
-            ) : (
-                <EmptyField />
-            )}
-            <TextField source="note" sortable={false} />
-            <DateField source="created_at" sortable={false} />
-            <DateField source="updated_at" sortable={false} />
-            {PermissionsStore.getResourcePermission('adminnotes', 'edit') ? <EditButton /> : null}
-            <ShowButton />
-            {PermissionsStore.getResourcePermission('adminnotes', 'remove') ? (
-                <DeleteButton />
-            ) : null}
-        </EditableDatagrid>
+        <Responsive
+            small={<SimpleList primaryText={record => `Note: ${record.note}`} />}
+            medium={
+                <EditableDatagrid bodyOptions={{ showRowHover: true }}>
+                    <NumberField source="id" sortable={false} />
+                    {PermissionsStore.getResourcePermission('users', 'list') ? (
+                        <ReferenceField
+                            label="User"
+                            source="user_id"
+                            reference="users"
+                            sortable={false}
+                            linkType="show"
+                            allowEmpty
+                        >
+                            <TextField source="username" />
+                        </ReferenceField>
+                    ) : (
+                        <EmptyField />
+                    )}
+                    {PermissionsStore.getResourcePermission('users', 'list') ? (
+                        <ReferenceField
+                            label="User"
+                            source="creator_id"
+                            reference="users"
+                            sortable={false}
+                            linkType="show"
+                            allowEmpty
+                        >
+                            <TextField source="username" />
+                        </ReferenceField>
+                    ) : (
+                        <EmptyField />
+                    )}
+                    <TextField source="note" sortable={false} />
+                    <DateField source="created_at" sortable={false} />
+                    <DateField source="updated_at" sortable={false} />
+                    {PermissionsStore.getResourcePermission('adminnotes', 'edit') ? (
+                        <EditButton />
+                    ) : null}
+                    <ShowButton />
+                    {PermissionsStore.getResourcePermission('adminnotes', 'remove') ? (
+                        <DeleteButton />
+                    ) : null}
+                </EditableDatagrid>
+            }
+        />
     </List>
 );
 

--- a/admin/src/resources/Country.js
+++ b/admin/src/resources/Country.js
@@ -3,17 +3,35 @@
  * When regenerated the changes will be lost.
  **/
 import React from 'react';
-import { List, TextField, Show, SimpleShowLayout, ShowButton } from 'admin-on-rest';
+import {
+    List,
+    TextField,
+    Responsive,
+    SimpleList,
+    Show,
+    SimpleShowLayout,
+    ShowButton
+} from 'admin-on-rest';
 import CountryFilter from '../filters/CountryFilter';
 import EditableDatagrid from '../grids/EditableDatagrid';
 
 export const CountryList = props => (
     <List {...props} title="Country List" filters={<CountryFilter />}>
-        <EditableDatagrid bodyOptions={{ showRowHover: true }}>
-            <TextField source="code" sortable={false} />
-            <TextField source="name" sortable={false} />
-            <ShowButton />
-        </EditableDatagrid>
+        <Responsive
+            small={
+                <SimpleList
+                    primaryText={record => `Code: ${record.code}`}
+                    secondaryText={record => `Name: ${record.name}`}
+                />
+            }
+            medium={
+                <EditableDatagrid bodyOptions={{ showRowHover: true }}>
+                    <TextField source="code" sortable={false} />
+                    <TextField source="name" sortable={false} />
+                    <ShowButton />
+                </EditableDatagrid>
+            }
+        />
     </List>
 );
 

--- a/admin/src/resources/Country.js
+++ b/admin/src/resources/Country.js
@@ -3,7 +3,7 @@
  * When regenerated the changes will be lost.
  **/
 import React from 'react';
-import { List, Datagrid, TextField, Show, SimpleShowLayout, ShowButton } from 'admin-on-rest';
+import { List, TextField, Show, SimpleShowLayout, ShowButton } from 'admin-on-rest';
 import CountryFilter from '../filters/CountryFilter';
 import EditableDatagrid from '../grids/EditableDatagrid';
 

--- a/admin/src/resources/DeletedUser.js
+++ b/admin/src/resources/DeletedUser.js
@@ -9,6 +9,8 @@ import {
     TextField,
     DateField,
     ReferenceField,
+    Responsive,
+    SimpleList,
     SimpleForm,
     Create,
     TextInput,
@@ -67,35 +69,47 @@ const validationEditDeletedUser = values => {
 
 export const DeletedUserList = props => (
     <List {...props} title="DeletedUser List" filters={<DeletedUserFilter />}>
-        <EditableDatagrid bodyOptions={{ showRowHover: true }}>
-            <TextField source="id" sortable={false} />
-            <TextField source="username" sortable={false} />
-            <TextField source="email" sortable={false} />
-            <TextField source="msisdn" sortable={false} />
-            <TextField source="reason" sortable={false} />
-            <DateField source="created_at" sortable={false} />
-            <DateField source="updated_at" sortable={false} />
-            <DateField source="deleted_at" sortable={false} />
-            {PermissionsStore.getResourcePermission('deleters', 'list') ? (
-                <ReferenceField
-                    label="Deleter"
-                    source="deleter_id"
-                    reference="deleters"
-                    sortable={false}
-                    linkType="show"
-                    allowEmpty
-                >
-                    <TextField source="" />
-                </ReferenceField>
-            ) : (
-                <EmptyField />
-            )}
-            {PermissionsStore.getResourcePermission('deletedusers', 'edit') ? <EditButton /> : null}
-            <ShowButton />
-            {PermissionsStore.getResourcePermission('deletedusers', 'remove') ? (
-                <DeleteButton />
-            ) : null}
-        </EditableDatagrid>
+        <Responsive
+            small={
+                <SimpleList
+                    primaryText={record => `Username: ${record.username}`}
+                    secondaryText={record => `Email: ${record.email}`}
+                />
+            }
+            medium={
+                <EditableDatagrid bodyOptions={{ showRowHover: true }}>
+                    <TextField source="id" sortable={false} />
+                    <TextField source="username" sortable={false} />
+                    <TextField source="email" sortable={false} />
+                    <TextField source="msisdn" sortable={false} />
+                    <TextField source="reason" sortable={false} />
+                    <DateField source="created_at" sortable={false} />
+                    <DateField source="updated_at" sortable={false} />
+                    <DateField source="deleted_at" sortable={false} />
+                    {PermissionsStore.getResourcePermission('deleters', 'list') ? (
+                        <ReferenceField
+                            label="Deleter"
+                            source="deleter_id"
+                            reference="deleters"
+                            sortable={false}
+                            linkType="show"
+                            allowEmpty
+                        >
+                            <TextField source="" />
+                        </ReferenceField>
+                    ) : (
+                        <EmptyField />
+                    )}
+                    {PermissionsStore.getResourcePermission('deletedusers', 'edit') ? (
+                        <EditButton />
+                    ) : null}
+                    <ShowButton />
+                    {PermissionsStore.getResourcePermission('deletedusers', 'remove') ? (
+                        <DeleteButton />
+                    ) : null}
+                </EditableDatagrid>
+            }
+        />
     </List>
 );
 

--- a/admin/src/resources/Domain.js
+++ b/admin/src/resources/Domain.js
@@ -10,6 +10,8 @@ import {
     ReferenceField,
     TextField,
     DateField,
+    Responsive,
+    SimpleList,
     SimpleForm,
     Create,
     ReferenceInput,
@@ -44,30 +46,44 @@ const validationEditDomain = values => {
 
 export const DomainList = props => (
     <List {...props} title="Domain List" filters={<DomainFilter />}>
-        <EditableDatagrid bodyOptions={{ showRowHover: true }}>
-            <NumberField source="id" sortable={false} />
-            {PermissionsStore.getResourcePermission('domains', 'list') ? (
-                <ReferenceField
-                    label="Parent"
-                    source="parent_id"
-                    reference="domains"
-                    sortable={false}
-                    linkType="show"
-                    allowEmpty
-                >
-                    <NumberField source="name" />
-                </ReferenceField>
-            ) : (
-                <EmptyField />
-            )}
-            <TextField source="name" sortable={false} />
-            <TextField source="description" sortable={false} />
-            <DateField source="created_at" sortable={false} />
-            <DateField source="updated_at" sortable={false} />
-            {PermissionsStore.getResourcePermission('domains', 'edit') ? <EditButton /> : null}
-            <ShowButton />
-            {PermissionsStore.getResourcePermission('domains', 'remove') ? <DeleteButton /> : null}
-        </EditableDatagrid>
+        <Responsive
+            small={
+                <SimpleList
+                    primaryText={record => `Name: ${record.name}`}
+                    secondaryText={record => `Description: ${record.description}`}
+                />
+            }
+            medium={
+                <EditableDatagrid bodyOptions={{ showRowHover: true }}>
+                    <NumberField source="id" sortable={false} />
+                    {PermissionsStore.getResourcePermission('domains', 'list') ? (
+                        <ReferenceField
+                            label="Parent"
+                            source="parent_id"
+                            reference="domains"
+                            sortable={false}
+                            linkType="show"
+                            allowEmpty
+                        >
+                            <NumberField source="name" />
+                        </ReferenceField>
+                    ) : (
+                        <EmptyField />
+                    )}
+                    <TextField source="name" sortable={false} />
+                    <TextField source="description" sortable={false} />
+                    <DateField source="created_at" sortable={false} />
+                    <DateField source="updated_at" sortable={false} />
+                    {PermissionsStore.getResourcePermission('domains', 'edit') ? (
+                        <EditButton />
+                    ) : null}
+                    <ShowButton />
+                    {PermissionsStore.getResourcePermission('domains', 'remove') ? (
+                        <DeleteButton />
+                    ) : null}
+                </EditableDatagrid>
+            }
+        />
     </List>
 );
 

--- a/admin/src/resources/Invitation.js
+++ b/admin/src/resources/Invitation.js
@@ -10,6 +10,8 @@ import {
     ReferenceField,
     NumberField,
     DateField,
+    Responsive,
+    SimpleList,
     SimpleForm,
     Create,
     TextInput,
@@ -79,48 +81,60 @@ export const InvitationList = props => (
         actions={<InvitationListActions />}
         filters={<InvitationFilter />}
     >
-        <EditableDatagrid bodyOptions={{ showRowHover: true }}>
-            <TextField source="id" sortable={false} />
-            {PermissionsStore.getResourcePermission('users', 'list') ? (
-                <ReferenceField
-                    label="User"
-                    source="invitor_id"
-                    reference="users"
-                    sortable={false}
-                    linkType="show"
-                    allowEmpty
-                >
-                    <TextField source="username" />
-                </ReferenceField>
-            ) : (
-                <EmptyField />
-            )}
-            <TextField source="first_name" sortable={false} />
-            <TextField source="last_name" sortable={false} />
-            <TextField source="email" sortable={false} />
-            {PermissionsStore.getResourcePermission('organisations', 'list') ? (
-                <ReferenceField
-                    label="Organisation"
-                    source="organisation_id"
-                    reference="organisations"
-                    sortable={false}
-                    linkType="show"
-                    allowEmpty
-                >
-                    <NumberField source="name" />
-                </ReferenceField>
-            ) : (
-                <EmptyField />
-            )}
-            <DateField source="expires_at" sortable={false} />
-            <DateField source="created_at" sortable={false} />
-            <DateField source="updated_at" sortable={false} />
-            {PermissionsStore.getResourcePermission('invitations', 'edit') ? <EditButton /> : null}
-            <ShowButton />
-            {PermissionsStore.getResourcePermission('invitations', 'remove') ? (
-                <DeleteButton />
-            ) : null}
-        </EditableDatagrid>
+        <Responsive
+            small={
+                <SimpleList
+                    primaryText={record => `First Name: ${record.first_name}`}
+                    secondaryText={record => `Email: ${record.email}`}
+                />
+            }
+            medium={
+                <EditableDatagrid bodyOptions={{ showRowHover: true }}>
+                    <TextField source="id" sortable={false} />
+                    {PermissionsStore.getResourcePermission('users', 'list') ? (
+                        <ReferenceField
+                            label="User"
+                            source="invitor_id"
+                            reference="users"
+                            sortable={false}
+                            linkType="show"
+                            allowEmpty
+                        >
+                            <TextField source="username" />
+                        </ReferenceField>
+                    ) : (
+                        <EmptyField />
+                    )}
+                    <TextField source="first_name" sortable={false} />
+                    <TextField source="last_name" sortable={false} />
+                    <TextField source="email" sortable={false} />
+                    {PermissionsStore.getResourcePermission('organisations', 'list') ? (
+                        <ReferenceField
+                            label="Organisation"
+                            source="organisation_id"
+                            reference="organisations"
+                            sortable={false}
+                            linkType="show"
+                            allowEmpty
+                        >
+                            <NumberField source="name" />
+                        </ReferenceField>
+                    ) : (
+                        <EmptyField />
+                    )}
+                    <DateField source="expires_at" sortable={false} />
+                    <DateField source="created_at" sortable={false} />
+                    <DateField source="updated_at" sortable={false} />
+                    {PermissionsStore.getResourcePermission('invitations', 'edit') ? (
+                        <EditButton />
+                    ) : null}
+                    <ShowButton />
+                    {PermissionsStore.getResourcePermission('invitations', 'remove') ? (
+                        <DeleteButton />
+                    ) : null}
+                </EditableDatagrid>
+            }
+        />
     </List>
 );
 

--- a/admin/src/resources/Invitation.js
+++ b/admin/src/resources/Invitation.js
@@ -27,6 +27,7 @@ import {
 } from 'admin-on-rest';
 import PermissionsStore from '../auth/PermissionsStore';
 import EmptyField from '../fields/EmptyField';
+import IdenticonField from '../fields/IndeticonField';
 import DateTimeInput from 'aor-datetime-input';
 import InvitationFilter from '../filters/InvitationFilter';
 import InvitationListActions from '../customActions/InvitationList'; 
@@ -90,7 +91,7 @@ export const InvitationList = props => (
             }
             medium={
                 <EditableDatagrid bodyOptions={{ showRowHover: true }}>
-                    <TextField source="id" sortable={false} />
+                    <IdenticonField source="id" sortable={false} />
                     {PermissionsStore.getResourcePermission('users', 'list') ? (
                         <ReferenceField
                             label="User"

--- a/admin/src/resources/Organisation.js
+++ b/admin/src/resources/Organisation.js
@@ -8,6 +8,8 @@ import {
     NumberField,
     TextField,
     DateField,
+    Responsive,
+    SimpleList,
     SimpleForm,
     Create,
     TextInput,
@@ -19,6 +21,7 @@ import {
     ShowButton
 } from 'admin-on-rest';
 import PermissionsStore from '../auth/PermissionsStore';
+import EmptyField from '../fields/EmptyField';
 import OrganisationFilter from '../filters/OrganisationFilter';
 import EditableDatagrid from '../grids/EditableDatagrid';
 
@@ -37,20 +40,30 @@ const validationEditOrganisation = values => {
 
 export const OrganisationList = props => (
     <List {...props} title="Organisation List" filters={<OrganisationFilter />}>
-        <EditableDatagrid bodyOptions={{ showRowHover: true }}>
-            <NumberField source="id" sortable={false} />
-            <TextField source="name" sortable={false} />
-            <TextField source="description" sortable={false} />
-            <DateField source="created_at" sortable={false} />
-            <DateField source="updated_at" sortable={false} />
-            {PermissionsStore.getResourcePermission('organisations', 'edit') ? (
-                <EditButton />
-            ) : null}
-            <ShowButton />
-            {PermissionsStore.getResourcePermission('organisations', 'remove') ? (
-                <DeleteButton />
-            ) : null}
-        </EditableDatagrid>
+        <Responsive
+            small={
+                <SimpleList
+                    primaryText={record => `Name: ${record.name}`}
+                    secondaryText={record => `Description: ${record.description}`}
+                />
+            }
+            medium={
+                <EditableDatagrid bodyOptions={{ showRowHover: true }}>
+                    <NumberField source="id" sortable={false} />
+                    <TextField source="name" sortable={false} />
+                    <TextField source="description" sortable={false} />
+                    <DateField source="created_at" sortable={false} />
+                    <DateField source="updated_at" sortable={false} />
+                    {PermissionsStore.getResourcePermission('organisations', 'edit') ? (
+                        <EditButton />
+                    ) : null}
+                    <ShowButton />
+                    {PermissionsStore.getResourcePermission('organisations', 'remove') ? (
+                        <DeleteButton />
+                    ) : null}
+                </EditableDatagrid>
+            }
+        />
     </List>
 );
 

--- a/admin/src/resources/Permission.js
+++ b/admin/src/resources/Permission.js
@@ -8,6 +8,8 @@ import {
     NumberField,
     TextField,
     DateField,
+    Responsive,
+    SimpleList,
     SimpleForm,
     Create,
     TextInput,
@@ -19,6 +21,7 @@ import {
     ShowButton
 } from 'admin-on-rest';
 import PermissionsStore from '../auth/PermissionsStore';
+import EmptyField from '../fields/EmptyField';
 import PermissionFilter from '../filters/PermissionFilter';
 import EditableDatagrid from '../grids/EditableDatagrid';
 
@@ -37,18 +40,30 @@ const validationEditPermission = values => {
 
 export const PermissionList = props => (
     <List {...props} title="Permission List" filters={<PermissionFilter />}>
-        <EditableDatagrid bodyOptions={{ showRowHover: true }}>
-            <NumberField source="id" sortable={false} />
-            <TextField source="name" sortable={false} />
-            <TextField source="description" sortable={false} />
-            <DateField source="created_at" sortable={false} />
-            <DateField source="updated_at" sortable={false} />
-            {PermissionsStore.getResourcePermission('permissions', 'edit') ? <EditButton /> : null}
-            <ShowButton />
-            {PermissionsStore.getResourcePermission('permissions', 'remove') ? (
-                <DeleteButton />
-            ) : null}
-        </EditableDatagrid>
+        <Responsive
+            small={
+                <SimpleList
+                    primaryText={record => `Name: ${record.name}`}
+                    secondaryText={record => `Description: ${record.description}`}
+                />
+            }
+            medium={
+                <EditableDatagrid bodyOptions={{ showRowHover: true }}>
+                    <NumberField source="id" sortable={false} />
+                    <TextField source="name" sortable={false} />
+                    <TextField source="description" sortable={false} />
+                    <DateField source="created_at" sortable={false} />
+                    <DateField source="updated_at" sortable={false} />
+                    {PermissionsStore.getResourcePermission('permissions', 'edit') ? (
+                        <EditButton />
+                    ) : null}
+                    <ShowButton />
+                    {PermissionsStore.getResourcePermission('permissions', 'remove') ? (
+                        <DeleteButton />
+                    ) : null}
+                </EditableDatagrid>
+            }
+        />
     </List>
 );
 

--- a/admin/src/resources/Resource.js
+++ b/admin/src/resources/Resource.js
@@ -9,6 +9,8 @@ import {
     UrlField,
     TextField,
     DateField,
+    Responsive,
+    SimpleList,
     SimpleForm,
     Create,
     TextInput,
@@ -20,6 +22,7 @@ import {
     ShowButton
 } from 'admin-on-rest';
 import PermissionsStore from '../auth/PermissionsStore';
+import EmptyField from '../fields/EmptyField';
 import ResourceFilter from '../filters/ResourceFilter';
 import EditableDatagrid from '../grids/EditableDatagrid';
 
@@ -38,18 +41,30 @@ const validationEditResource = values => {
 
 export const ResourceList = props => (
     <List {...props} title="Resource List" filters={<ResourceFilter />}>
-        <EditableDatagrid bodyOptions={{ showRowHover: true }}>
-            <NumberField source="id" sortable={false} />
-            <UrlField source="urn" sortable={false} />
-            <TextField source="description" sortable={false} />
-            <DateField source="created_at" sortable={false} />
-            <DateField source="updated_at" sortable={false} />
-            {PermissionsStore.getResourcePermission('resources', 'edit') ? <EditButton /> : null}
-            <ShowButton />
-            {PermissionsStore.getResourcePermission('resources', 'remove') ? (
-                <DeleteButton />
-            ) : null}
-        </EditableDatagrid>
+        <Responsive
+            small={
+                <SimpleList
+                    primaryText={record => `Urn: ${record.urn}`}
+                    secondaryText={record => `Description: ${record.description}`}
+                />
+            }
+            medium={
+                <EditableDatagrid bodyOptions={{ showRowHover: true }}>
+                    <NumberField source="id" sortable={false} />
+                    <UrlField source="urn" sortable={false} />
+                    <TextField source="description" sortable={false} />
+                    <DateField source="created_at" sortable={false} />
+                    <DateField source="updated_at" sortable={false} />
+                    {PermissionsStore.getResourcePermission('resources', 'edit') ? (
+                        <EditButton />
+                    ) : null}
+                    <ShowButton />
+                    {PermissionsStore.getResourcePermission('resources', 'remove') ? (
+                        <DeleteButton />
+                    ) : null}
+                </EditableDatagrid>
+            }
+        />
     </List>
 );
 

--- a/admin/src/resources/Role.js
+++ b/admin/src/resources/Role.js
@@ -10,6 +10,8 @@ import {
     TextField,
     BooleanField,
     DateField,
+    Responsive,
+    SimpleList,
     SimpleForm,
     Create,
     TextInput,
@@ -43,17 +45,26 @@ const validationEditRole = values => {
 
 export const RoleList = props => (
     <List {...props} title="Role List" filters={<RoleFilter />}>
-        <EditableDatagrid bodyOptions={{ showRowHover: true }}>
-            <NumberField source="id" sortable={false} />
-            <TextField source="label" sortable={false} />
-            <BooleanField source="requires_2fa" sortable={false} />
-            <TextField source="description" sortable={false} />
-            <DateField source="created_at" sortable={false} />
-            <DateField source="updated_at" sortable={false} />
-            {PermissionsStore.getResourcePermission('roles', 'edit') ? <EditButton /> : null}
-            <ShowButton />
-            {PermissionsStore.getResourcePermission('roles', 'remove') ? <DeleteButton /> : null}
-        </EditableDatagrid>
+        <Responsive
+            small={<SimpleList primaryText={record => `Label: ${record.label}`} />}
+            medium={
+                <EditableDatagrid bodyOptions={{ showRowHover: true }}>
+                    <NumberField source="id" sortable={false} />
+                    <TextField source="label" sortable={false} />
+                    <BooleanField source="requires_2fa" sortable={false} />
+                    <TextField source="description" sortable={false} />
+                    <DateField source="created_at" sortable={false} />
+                    <DateField source="updated_at" sortable={false} />
+                    {PermissionsStore.getResourcePermission('roles', 'edit') ? (
+                        <EditButton />
+                    ) : null}
+                    <ShowButton />
+                    {PermissionsStore.getResourcePermission('roles', 'remove') ? (
+                        <DeleteButton />
+                    ) : null}
+                </EditableDatagrid>
+            }
+        />
     </List>
 );
 

--- a/admin/src/resources/Site.js
+++ b/admin/src/resources/Site.js
@@ -11,6 +11,8 @@ import {
     TextField,
     BooleanField,
     DateField,
+    Responsive,
+    SimpleList,
     SimpleForm,
     Create,
     ReferenceInput,
@@ -49,45 +51,59 @@ const validationEditSite = values => {
 
 export const SiteList = props => (
     <List {...props} title="Site List" filters={<SiteFilter />}>
-        <EditableDatagrid bodyOptions={{ showRowHover: true }}>
-            <NumberField source="id" sortable={false} />
-            {PermissionsStore.getResourcePermission('clients', 'list') ? (
-                <ReferenceField
-                    label="Client"
-                    source="client_id"
-                    reference="clients"
-                    sortable={false}
-                    linkType="show"
-                    allowEmpty
-                >
-                    <NumberField source="name" />
-                </ReferenceField>
-            ) : (
-                <EmptyField />
-            )}
-            {PermissionsStore.getResourcePermission('domains', 'list') ? (
-                <ReferenceField
-                    label="Domain"
-                    source="domain_id"
-                    reference="domains"
-                    sortable={false}
-                    linkType="show"
-                    allowEmpty
-                >
-                    <NumberField source="name" />
-                </ReferenceField>
-            ) : (
-                <EmptyField />
-            )}
-            <TextField source="name" sortable={false} />
-            <TextField source="description" sortable={false} />
-            <BooleanField source="is_active" sortable={false} />
-            <DateField source="created_at" sortable={false} />
-            <DateField source="updated_at" sortable={false} />
-            {PermissionsStore.getResourcePermission('sites', 'edit') ? <EditButton /> : null}
-            <ShowButton />
-            {PermissionsStore.getResourcePermission('sites', 'remove') ? <DeleteButton /> : null}
-        </EditableDatagrid>
+        <Responsive
+            small={
+                <SimpleList
+                    primaryText={record => `Name: ${record.name}`}
+                    secondaryText={record => `Description: ${record.description}`}
+                />
+            }
+            medium={
+                <EditableDatagrid bodyOptions={{ showRowHover: true }}>
+                    <NumberField source="id" sortable={false} />
+                    {PermissionsStore.getResourcePermission('clients', 'list') ? (
+                        <ReferenceField
+                            label="Client"
+                            source="client_id"
+                            reference="clients"
+                            sortable={false}
+                            linkType="show"
+                            allowEmpty
+                        >
+                            <NumberField source="name" />
+                        </ReferenceField>
+                    ) : (
+                        <EmptyField />
+                    )}
+                    {PermissionsStore.getResourcePermission('domains', 'list') ? (
+                        <ReferenceField
+                            label="Domain"
+                            source="domain_id"
+                            reference="domains"
+                            sortable={false}
+                            linkType="show"
+                            allowEmpty
+                        >
+                            <NumberField source="name" />
+                        </ReferenceField>
+                    ) : (
+                        <EmptyField />
+                    )}
+                    <TextField source="name" sortable={false} />
+                    <TextField source="description" sortable={false} />
+                    <BooleanField source="is_active" sortable={false} />
+                    <DateField source="created_at" sortable={false} />
+                    <DateField source="updated_at" sortable={false} />
+                    {PermissionsStore.getResourcePermission('sites', 'edit') ? (
+                        <EditButton />
+                    ) : null}
+                    <ShowButton />
+                    {PermissionsStore.getResourcePermission('sites', 'remove') ? (
+                        <DeleteButton />
+                    ) : null}
+                </EditableDatagrid>
+            }
+        />
     </List>
 );
 

--- a/admin/src/resources/User.js
+++ b/admin/src/resources/User.js
@@ -32,6 +32,7 @@ import CardTitle from 'material-ui/Card/CardTitle';
 import FieldSelectDatagrid from '../grids/FieldSelectDatagrid';
 import PermissionsStore from '../auth/PermissionsStore';
 import EmptyField from '../fields/EmptyField';
+import IdenticonField from '../fields/IndeticonField';
 import ObjectField from '../fields/ObjectField';
 import UserFilter from '../filters/UserFilter';
 import UserShowActions from '../customActions/UserShow';
@@ -58,7 +59,7 @@ export const UserList = props => (
             defaultHiddenFields={hiddenFields}
             bodyOptions={{ showRowHover: true }}
         >
-            <TextField source="id" />
+            <IdenticonField source="id" />
             <TextField source="username" sortable={false} />
             <TextField source="first_name" sortable={false} />
             <TextField source="last_name" sortable={false} />

--- a/admin/src/resources/User.js
+++ b/admin/src/resources/User.js
@@ -12,6 +12,8 @@ import {
     UrlField,
     ReferenceField,
     NumberField,
+    Responsive,
+    SimpleList,
     Show,
     SimpleShowLayout,
     ReferenceManyField,
@@ -55,57 +57,69 @@ export const UserListNoSites = props => (
 
 export const UserList = props => (
     <List {...props} title="User List" filters={<UserFilter />}>
-        <FieldSelectDatagrid
-            defaultHiddenFields={hiddenFields}
-            bodyOptions={{ showRowHover: true }}
-        >
-            <IdenticonField source="id" />
-            <TextField source="username" sortable={false} />
-            <TextField source="first_name" sortable={false} />
-            <TextField source="last_name" sortable={false} />
-            <TextField source="email" sortable={false} />
-            <BooleanField source="is_active" sortable={false} />
-            <DateField source="date_joined" sortable={false} />
-            <DateField source="last_login" sortable={false} />
-            <BooleanField source="email_verified" sortable={false} />
-            <BooleanField source="msisdn_verified" sortable={false} />
-            <TextField source="msisdn" sortable={false} />
-            <TextField source="gender" sortable={false} />
-            <DateField source="birth_date" sortable={false} />
-            <UrlField source="avatar" sortable={false} />
-            {PermissionsStore.getResourcePermission('countries', 'list') ? (
-                <ReferenceField
-                    label="Country"
-                    source="country_code"
-                    reference="countries"
-                    sortable={false}
-                    linkType="show"
-                    allowEmpty
+        <Responsive
+            small={
+                <SimpleList
+                    primaryText={record => `Username: ${record.username}`}
+                    secondaryText={record => `Email: ${record.email}`}
+                />
+            }
+            medium={
+                <FieldSelectDatagrid
+                    defaultHiddenFields={hiddenFields}
+                    bodyOptions={{ showRowHover: true }}
                 >
-                    <TextField source="name" />
-                </ReferenceField>
-            ) : (
-                <EmptyField />
-            )}
-            {PermissionsStore.getResourcePermission('organisations', 'list') ? (
-                <ReferenceField
-                    label="Organisation"
-                    source="organisation_id"
-                    reference="organisations"
-                    sortable={false}
-                    linkType="show"
-                    allowEmpty
-                >
-                    <NumberField source="name" />
-                </ReferenceField>
-            ) : (
-                <EmptyField />
-            )}
-            <DateField source="created_at" sortable={false} />
-            <DateField source="updated_at" sortable={false} />
-            {PermissionsStore.getResourcePermission('users', 'edit') ? <EditButton /> : null}
-            <ShowButton />
-        </FieldSelectDatagrid>
+                    <IdenticonField source="id" />
+                    <TextField source="username" sortable={false} />
+                    <TextField source="first_name" sortable={false} />
+                    <TextField source="last_name" sortable={false} />
+                    <TextField source="email" sortable={false} />
+                    <BooleanField source="is_active" sortable={false} />
+                    <DateField source="date_joined" sortable={false} />
+                    <DateField source="last_login" sortable={false} />
+                    <BooleanField source="email_verified" sortable={false} />
+                    <BooleanField source="msisdn_verified" sortable={false} />
+                    <TextField source="msisdn" sortable={false} />
+                    <TextField source="gender" sortable={false} />
+                    <DateField source="birth_date" sortable={false} />
+                    <UrlField source="avatar" sortable={false} />
+                    {PermissionsStore.getResourcePermission('countries', 'list') ? (
+                        <ReferenceField
+                            label="Country"
+                            source="country_code"
+                            reference="countries"
+                            sortable={false}
+                            linkType="show"
+                            allowEmpty
+                        >
+                            <TextField source="name" />
+                        </ReferenceField>
+                    ) : (
+                        <EmptyField />
+                    )}
+                    {PermissionsStore.getResourcePermission('organisations', 'list') ? (
+                        <ReferenceField
+                            label="Organisation"
+                            source="organisation_id"
+                            reference="organisations"
+                            sortable={false}
+                            linkType="show"
+                            allowEmpty
+                        >
+                            <NumberField source="name" />
+                        </ReferenceField>
+                    ) : (
+                        <EmptyField />
+                    )}
+                    <DateField source="created_at" sortable={false} />
+                    <DateField source="updated_at" sortable={false} />
+                    {PermissionsStore.getResourcePermission('users', 'edit') ? (
+                        <EditButton />
+                    ) : null}
+                    <ShowButton />
+                </FieldSelectDatagrid>
+            }
+        />
     </List>
 );
 

--- a/admin/yarn.lock
+++ b/admin/yarn.lock
@@ -5942,6 +5942,12 @@ react-beautiful-dnd@^9.0.2:
     redux "^4.0.0"
     tiny-invariant "^1.0.0"
 
+react-blockies@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/react-blockies/-/react-blockies-1.3.0.tgz#2db6123bdfa8295a32dfa8acb62ce88abd1090e3"
+  dependencies:
+    prop-types "^15.5.10"
+
 react-dev-utils@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/react-dev-utils/-/react-dev-utils-5.0.0.tgz#425ac7c9c40c2603bc4f7ab8836c1406e96bb473"

--- a/swagger/management_layer.yml
+++ b/swagger/management_layer.yml
@@ -4417,6 +4417,9 @@ x-detail-page-definitions:
         - role_id
         - created_at
         - updated_at
+    responsive_fields:
+      primary: name
+      secondary: description
   invitation:
     inlines:
     - model: invitation_domain_role
@@ -4435,6 +4438,17 @@ x-detail-page-definitions:
         - role_id
         - created_at
         - updated_at
+    responsive_fields:
+      primary: first_name
+      secondary: email
+  permission:
+    responsive_fields:
+      primary: name
+      secondary: description
+  resource:
+    responsive_fields:
+      primary: urn
+      secondary: description
   role:
     inlines:
     - model: role_resource_permission
@@ -4445,6 +4459,8 @@ x-detail-page-definitions:
         - permission_id
         - created_at
         - updated_at
+    responsive_fields:
+      primary: label
   site:
     inlines:
     - model: site_role
@@ -4454,6 +4470,20 @@ x-detail-page-definitions:
         - role_id
         - created_at
         - updated_at
+    responsive_fields:
+      primary: name
+      secondary: description
+  adminnote:
+    responsive_fields:
+      primary: note
+  country:
+    responsive_fields:
+      primary: code
+      secondary: name
+  organisation:
+    responsive_fields:
+      primary: name
+      secondary: description
   user:
     inlines:
     - model: user_domain_role
@@ -4481,6 +4511,9 @@ x-detail-page-definitions:
         - role_id
         - created_at
         - updated_at
+    responsive_fields:
+      primary: username
+      secondary: email
     sortable_fields:
       - id
   deleteduser:
@@ -4496,4 +4529,7 @@ x-detail-page-definitions:
       - deletion_confirmed_via
       - created_at
       - updated_at
+    responsive_fields:
+      primary: username
+      secondary: email
 


### PR DESCRIPTION
PART 1

**Background:** Smaller screens were cutting off a lot of the listing fields and making the site difficult to use.

**What was done**: In this part of improvements:

- An identicon field was added and replaced the uuid fields of user and invitation ids. The colour scheme of the identicons were made to follow that of the site UI. Shown below:

![screenshot from 2018-09-07 14-34-01](https://user-images.githubusercontent.com/20847795/45219406-18cc6400-b2ab-11e8-8f85-2abbd6c5adec.png)

- Responsive fields were declared in the swagger specifications for certain resources and then the code was regenerated and the list view components that were affected follow the Admin on Rest recommended approach: https://marmelab.com/react-admin/Theming.html#responsive-utility. 

