### PR TITLE
Feature/geinfra 280

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,8 @@ next
 - `ConfirmDialog` now supports optional text inputs with validation.
 - Added `reason` input to deleting a user, saves as field in DeletedUser entry.
 - Updated docker files to support production build with build args.
+- User delete button hidden on own user's show view.
+- Manage Roles pages only allow assignment of roles that are available on a given domain or site, more info shown if no roles are available.
 
 1.2.0
 -----

--- a/admin/src/actions/manageRoles.js
+++ b/admin/src/actions/manageRoles.js
@@ -31,10 +31,11 @@ export const deleteRole = key => ({
     payload: key
 });
 
-export const setAssignmentLocation = (managerRoles, key) => ({
+export const setAssignmentLocation = (managerRoles, availableRoles, key) => ({
     type: MANAGE_ROLES_SET_ASSIGNMENT_LOCATION,
     payload: {
         managerRoles,
+        availableRoles,
         key
     }
 });

--- a/admin/src/cards/AssignRoleCard.js
+++ b/admin/src/cards/AssignRoleCard.js
@@ -56,12 +56,12 @@ const AssignRoleCard = ({
                                 {availableRoles.length
                                     ? `The following roles are available: [${availableRoles.join(
                                           ', '
-                                      )}]\n`
+                                      )}]`
                                     : `No roles to Select on this domain/site.`}
                             </CardText>
-                            <CardText>{`You have the following roles here: [${currentRoles.join(
-                                ', '
-                            )}]`}</CardText>
+                            <CardText>
+                                {`You have the following roles here: [${currentRoles.join(', ')}]`}
+                            </CardText>
                         </React.Fragment>
                     )}
                 </React.Fragment>

--- a/admin/src/cards/AssignRoleCard.js
+++ b/admin/src/cards/AssignRoleCard.js
@@ -38,27 +38,32 @@ const AssignRoleCard = ({
             />
             {assignmentLocation && (
                 <React.Fragment>
-                    <CardText>
-                        {`The following roles are available: [${availableRoles.join(', ')}]\n`}
-                    </CardText>
-                    <CardText>{`You have: [${currentRoles.join(', ')}]`}</CardText>
-                    <CardText>
-                        {notEmptyObject(rolesToAssign) ? (
-                            <React.Fragment>
-                                <CardHeader subtitle="Please select roles to assign:" />
-                                {Object.values(rolesToAssign).map(role => (
-                                    <Checkbox
-                                        key={role.id}
-                                        label={role.label}
-                                        checked={role.checked}
-                                        onCheck={() => handleSelect(role.id)}
-                                    />
-                                ))}
-                            </React.Fragment>
-                        ) : (
-                            'No roles to Select on this domain/site.'
-                        )}
-                    </CardText>
+                    {notEmptyObject(rolesToAssign) ? (
+                        <React.Fragment>
+                            <CardHeader subtitle="Please select roles to assign:" />
+                            {Object.values(rolesToAssign).map(role => (
+                                <Checkbox
+                                    key={role.id}
+                                    label={role.label}
+                                    checked={role.checked}
+                                    onCheck={() => handleSelect(role.id)}
+                                />
+                            ))}
+                        </React.Fragment>
+                    ) : (
+                        <React.Fragment>
+                            <CardText>
+                                {availableRoles.length
+                                    ? `The following roles are available: [${availableRoles.join(
+                                          ', '
+                                      )}]\n`
+                                    : `No roles to Select on this domain/site.`}
+                            </CardText>
+                            <CardText>{`You have the following roles here: [${currentRoles.join(
+                                ', '
+                            )}]`}</CardText>
+                        </React.Fragment>
+                    )}
                 </React.Fragment>
             )}
             {amountSelectedToAssign > 0 && (

--- a/admin/src/cards/AssignRoleCard.js
+++ b/admin/src/cards/AssignRoleCard.js
@@ -15,6 +15,8 @@ const AssignRoleCard = ({
     amountSelectedToAssign,
     assigning,
     assignmentLocation,
+    availableRoles,
+    currentRoles,
     handleAssign,
     handleChange,
     handleSelect,
@@ -36,18 +38,26 @@ const AssignRoleCard = ({
             />
             {assignmentLocation && (
                 <React.Fragment>
-                    <CardHeader subtitle="Please choose the roles to add:" />
                     <CardText>
-                        {notEmptyObject(rolesToAssign)
-                            ? Object.values(rolesToAssign).map(role => (
-                                  <Checkbox
-                                      key={role.id}
-                                      label={role.label}
-                                      checked={role.checked}
-                                      onCheck={() => handleSelect(role.id)}
-                                  />
-                              ))
-                            : 'No roles to Select on this domain/site.'}
+                        {`The following roles are available: [${availableRoles.join(', ')}]\n`}
+                    </CardText>
+                    <CardText>{`You have: [${currentRoles.join(', ')}]`}</CardText>
+                    <CardText>
+                        {notEmptyObject(rolesToAssign) ? (
+                            <React.Fragment>
+                                <CardHeader subtitle="Please select roles to assign:" />
+                                {Object.values(rolesToAssign).map(role => (
+                                    <Checkbox
+                                        key={role.id}
+                                        label={role.label}
+                                        checked={role.checked}
+                                        onCheck={() => handleSelect(role.id)}
+                                    />
+                                ))}
+                            </React.Fragment>
+                        ) : (
+                            'No roles to Select on this domain/site.'
+                        )}
                     </CardText>
                 </React.Fragment>
             )}

--- a/admin/src/manageUtils.js
+++ b/admin/src/manageUtils.js
@@ -161,6 +161,21 @@ export const deleteRoles = props => {
     });
 };
 
+export const getAvailableRoles = (key, props) => {
+    const [placeType, id] = key.split(':');
+    const place = placeType === 'd' ? 'domain' : 'site';
+    restClient(GET_LIST, `${place}roles`, {
+        filter: {
+            [`${place}_id`]: id
+        }
+    }).then(response => {
+        const availableRoles = response.data.map(placeRole => {
+            return placeRole.role_id;
+        });
+        props.setAssignmentLocation(props.manageRoles.managerRoles, availableRoles, key);
+    });
+};
+
 export const assignRoles = props => {
     const store = props.manageRoles;
     const { resource, idLabel } = MANAGE_MAPPING[store.path];

--- a/admin/src/pages/ManageRoles/AssignRoleCard.js
+++ b/admin/src/pages/ManageRoles/AssignRoleCard.js
@@ -11,7 +11,7 @@ import {
 } from '../../actions/manageRoles';
 import PermissionsStore from '../../auth/PermissionsStore';
 import AssignRoleCard from '../../cards/AssignRoleCard';
-import { assignRoles } from '../../manageUtils';
+import { assignRoles, getAvailableRoles } from '../../manageUtils';
 
 const mapStateToProps = state => ({
     manageRoles: state.manageRoles
@@ -19,8 +19,8 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = dispatch => ({
     invalidToken: () => dispatch(invalidToken()),
-    setAssignmentLocation: (managerRoles, key) =>
-        dispatch(setAssignmentLocation(managerRoles, key)),
+    setAssignmentLocation: (managerRoles, availableRoles, key) =>
+        dispatch(setAssignmentLocation(managerRoles, availableRoles, key)),
     checkRoleForAssign: key => dispatch(checkRoleForAssign(key)),
     assigningRoles: assigning => dispatch(assigningRoles(assigning)),
     assignRole: (key, objectRole) => dispatch(assignRole(key, objectRole)),
@@ -39,7 +39,7 @@ class AssignUserRoleCard extends Component {
     }
 
     handleChange(key) {
-        this.props.setAssignmentLocation(this.props.manageRoles.managerRoles, key);
+        getAvailableRoles(key, this.props);
     }
 
     handleSelect(key) {
@@ -55,14 +55,25 @@ class AssignUserRoleCard extends Component {
             assigning,
             amountSelectedToAssign,
             assignmentLocation,
+            availableRoles,
+            managerRoles,
+            roleMapping,
             rolesToAssign
         } = this.props.manageRoles;
         const treeData = PermissionsStore.getTreeData();
+        const availableRoleLabels =
+            availableRoles && availableRoles.map(roleID => roleMapping[roleID].label);
+        const currentRoles =
+            assignmentLocation &&
+            managerRoles &&
+            managerRoles[assignmentLocation].map(role => role.label);
         return (
             <AssignRoleCard
                 amountSelectedToAssign={amountSelectedToAssign}
                 assigning={assigning}
                 assignmentLocation={assignmentLocation}
+                availableRoles={availableRoleLabels}
+                currentRoles={currentRoles}
                 handleAssign={this.handleAssign}
                 handleChange={this.handleChange}
                 handleSelect={this.handleSelect}

--- a/admin/src/reducers/manageRolesReducer.js
+++ b/admin/src/reducers/manageRolesReducer.js
@@ -44,14 +44,18 @@ export default (state = { validToken: true }, { type, payload }) => {
                 amountSelectedToDelete: state.amountSelectedToDelete - 1
             };
         case MANAGE_ROLES_SET_ASSIGNMENT_LOCATION:
+            const availableRolesSet = new Set(payload.availableRoles);
             return {
                 ...state,
                 assignmentLocation: payload.key,
-                rolesToAssign: payload.managerRoles[payload.key].reduce((accumulator, role) => {
-                    accumulator[role.id] = {
-                        ...role,
-                        checked: false
-                    };
+                availableRoles: payload.availableRoles,
+                rolesToAssign: state.managerRoles[payload.key].reduce((accumulator, role) => {
+                    if (availableRolesSet.has(role.id)) {
+                        accumulator[role.id] = {
+                            ...role,
+                            checked: false
+                        };
+                    }
                     return accumulator;
                 }, {}),
                 amountSelectedToAssign: 0
@@ -94,6 +98,7 @@ export default (state = { validToken: true }, { type, payload }) => {
         case MANAGE_ROLES_ALL_ASSIGNED:
             const {
                 assignmentLocation,
+                availableRoles,
                 rolesToAssign,
                 amountSelectedToAssign,
                 ...nextState


### PR DESCRIPTION
**Background:** The manage roles pages allow the user to assign roles. The roles they can assign are all the effective roles the user has on a given site or domain, however that domain or site may not have that role rule which allows that role to be assigned there, and the current manage roles page will throw a visual user error telling the user they cannot perform the action.

**What was done:** An intersection is done between the selected domain or site roles and the user's roles that can be assigned there. These are now the given choices of roles that can be assigned, avoiding the unhelpful error. Also more information is given when there are no roles to assign on a domain or site.