### PR TITLE
Context Changer now working with new RA setup

### DIFF
--- a/admin/package.json
+++ b/admin/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "react-admin": "^2.0.0",
-    "antd": "^3.6.4",
+    "antd": "3.6.4",
     "react-blockies": "^1.3.0",
     "jwt-decode": "^2.2.0",
     "query-string": "^5.0.0",

--- a/admin/src/customRoutes.js
+++ b/admin/src/customRoutes.js
@@ -2,14 +2,14 @@ import React from 'react';
 import { Route } from 'react-router-dom';
 
 import catchAll from './catchAll';
+import ContextChanger from './pages/ContextChanger';
 import LeavingPage from './pages/LeavingPage';
 import OIDCCallback from './auth/OIDCCallback';
 // import ManageRoles from './pages/ManageRoles';
-// import ContextChanger from './pages/ContextChanger';
 
 export default [
     <Route exact path="/oidc/callback" component={OIDCCallback} noLayout />,
-    // <Route exact path="/contextchanger" component={ContextChanger} noLayout />,
+    <Route exact path="/contextchanger" component={ContextChanger} noLayout />,
     <Route exact path="/leaving" component={LeavingPage} noLayout />,
     <Route exact path="/catchAll" component={catchAll} />,
     // <Route exact path="/manageinvitationroles/:invitation_id" component={ManageRoles} />,

--- a/admin/src/dataProvider.js
+++ b/admin/src/dataProvider.js
@@ -252,6 +252,9 @@ const convertHTTPResponseToREST = ({ response, type, resource, params }) => {
                     id: keys ? keys.map(key => json[key]).join('/') : pk ? json[pk] : json.id
                 }
             };
+        case GET_ONE:
+            data = keys ? { ...json, id: keys.map(key => json[key]).join('/') } : json;
+            return { data };
         default:
             return { data: json ? json : {} };
     }

--- a/admin/src/filters/DomainFilter.js
+++ b/admin/src/filters/DomainFilter.js
@@ -3,7 +3,8 @@
  * When regenerated the changes will be lost.
  **/
 import React from 'react';
-import { SelectInput, TextInput, ReferenceInput, Filter } from 'react-admin';
+import { TextInput, Filter } from 'react-admin';
+import DomainTreeInput from '../inputs/DomainTreeInput';
 
 const parseDomainIds = value => value.replace(/[^\w]/gi, ',');
 
@@ -21,9 +22,7 @@ const validateDomainIds = value => {
 
 const DomainFilter = props => (
     <Filter {...props}>
-        <ReferenceInput label="Parent Id" source="parent_id" reference="domains" allowEmpty>
-            <SelectInput optionText="name" />
-        </ReferenceInput>
+        <DomainTreeInput label="Parent Domain" source="parent_id" />
         <TextInput
             label="Domain Ids"
             source="domain_ids"

--- a/admin/src/filters/DomainRoleFilter.js
+++ b/admin/src/filters/DomainRoleFilter.js
@@ -4,12 +4,11 @@
  **/
 import React from 'react';
 import { SelectInput, ReferenceInput, Filter } from 'react-admin';
+import DomainTreeInput from '../inputs/DomainTreeInput';
 
 const DomainRoleFilter = props => (
     <Filter {...props}>
-        <ReferenceInput label="Domain" source="domain_id" reference="domains" allowEmpty>
-            <SelectInput optionText="name" />
-        </ReferenceInput>
+        <DomainTreeInput label="Domain" source="domain_id" />
         <ReferenceInput label="Role" source="role_id" reference="roles" allowEmpty>
             <SelectInput optionText="label" />
         </ReferenceInput>

--- a/admin/src/filters/InvitationDomainRoleFilter.js
+++ b/admin/src/filters/InvitationDomainRoleFilter.js
@@ -4,13 +4,12 @@
  **/
 import React from 'react';
 import { SelectInput, TextInput, ReferenceInput, Filter } from 'react-admin';
+import DomainTreeInput from '../inputs/DomainTreeInput';
 
 const InvitationDomainRoleFilter = props => (
     <Filter {...props}>
         <TextInput label="Invitation Id" source="invitation_id" />
-        <ReferenceInput label="Domain" source="domain_id" reference="domains" allowEmpty>
-            <SelectInput optionText="name" />
-        </ReferenceInput>
+        <DomainTreeInput label="Domain" source="domain_id" />
         <ReferenceInput label="Role" source="role_id" reference="roles" allowEmpty>
             <SelectInput optionText="label" />
         </ReferenceInput>

--- a/admin/src/filters/UserDomainRoleFilter.js
+++ b/admin/src/filters/UserDomainRoleFilter.js
@@ -4,13 +4,12 @@
  **/
 import React from 'react';
 import { SelectInput, TextInput, ReferenceInput, Filter } from 'react-admin';
+import DomainTreeInput from '../inputs/DomainTreeInput';
 
 const UserDomainRoleFilter = props => (
     <Filter {...props}>
         <TextInput label="User Id" source="user_id" />
-        <ReferenceInput label="Domain" source="domain_id" reference="domains" allowEmpty>
-            <SelectInput optionText="name" />
-        </ReferenceInput>
+        <DomainTreeInput label="Domain" source="domain_id" />
         <ReferenceInput label="Role" source="role_id" reference="roles" allowEmpty>
             <SelectInput optionText="label" />
         </ReferenceInput>

--- a/admin/src/inputs/DomainTreeInput.js
+++ b/admin/src/inputs/DomainTreeInput.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Field } from 'redux-form';
 
 import { getUntilDone, makeIDMapping, createTreeData } from '../utils';
-import CircularProgress from 'material-ui/CircularProgress/CircularProgress';
+import CircularProgress from '@material-ui/core/CircularProgress';
 import TreeviewSelect from './TreeviewSelect';
 
 class DomainTreeInput extends Component {
@@ -63,7 +63,7 @@ class DomainTreeInput extends Component {
     }
 
     render() {
-        const { useReduxFormField, value, source, label, onChange } = this.props;
+        const { useReduxFormField, value, source, label, onChange, customStyle } = this.props;
         const { treeData } = this.state;
         return treeData ? (
             <span>
@@ -72,7 +72,7 @@ class DomainTreeInput extends Component {
                         name={source}
                         component={TreeviewSelect}
                         label={label}
-                        props={{ treeData, label, onChange }}
+                        props={{ treeData, label, onChange, customStyle }}
                         parse={this.parser}
                         format={this.formatter}
                     />
@@ -83,6 +83,7 @@ class DomainTreeInput extends Component {
                         onChange={onChange}
                         value={value}
                         input={{}}
+                        customStyle={customStyle}
                     />
                 )}
             </span>
@@ -96,11 +97,13 @@ DomainTreeInput.propTypes = {
     value: PropTypes.string,
     onChange: PropTypes.func,
     onlyDomains: PropTypes.bool,
-    treeData: PropTypes.array
+    treeData: PropTypes.array,
+    customStyle: PropTypes.object
 };
 DomainTreeInput.defaultProps = {
     useReduxFormField: true,
-    onlyDomains: true
+    onlyDomains: true,
+    customStyle: null
 };
 
 export default DomainTreeInput;

--- a/admin/src/inputs/TreeviewSelect.js
+++ b/admin/src/inputs/TreeviewSelect.js
@@ -27,18 +27,20 @@ class TreeviewSelect extends Component {
     }
 
     render() {
-        const { label, treeData, showSearch } = this.props;
+        const { label, treeData, showSearch, customStyle } = this.props;
         const { value } = this.state;
         return (
             <TreeSelect
                 showSearch={showSearch}
                 treeData={treeData}
-                style={{
-                    fontSize: 16,
-                    height: 40,
-                    width: 256,
-                    marginTop: 40
-                }}
+                style={
+                    customStyle || {
+                        fontSize: 16,
+                        height: 40,
+                        width: 256,
+                        marginTop: 40
+                    }
+                }
                 value={value}
                 dropdownStyle={{
                     maxHeight: 400,
@@ -53,10 +55,12 @@ class TreeviewSelect extends Component {
 TreeviewSelect.propTypes = {
     onChange: PropTypes.func,
     showSearch: PropTypes.bool,
-    value: PropTypes.string
+    value: PropTypes.string,
+    customStyle: PropTypes.object
 };
 TreeviewSelect.defaultProps = {
-    showSearch: false
+    showSearch: false,
+    customStyle: null
 };
 
 export default TreeviewSelect;

--- a/admin/src/inputs/TreeviewSelect.js
+++ b/admin/src/inputs/TreeviewSelect.js
@@ -2,6 +2,8 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { TreeSelect } from 'antd';
 
+import { styles } from '../theme';
+
 class TreeviewSelect extends Component {
     constructor(props) {
         super(props);
@@ -34,12 +36,7 @@ class TreeviewSelect extends Component {
                 showSearch={showSearch}
                 treeData={treeData}
                 style={
-                    customStyle || {
-                        fontSize: 16,
-                        height: 40,
-                        width: 256,
-                        marginTop: 40
-                    }
+                    customStyle || styles.treeSelect
                 }
                 value={value}
                 dropdownStyle={{

--- a/admin/src/pages/ContextChanger.js
+++ b/admin/src/pages/ContextChanger.js
@@ -1,17 +1,18 @@
 import jwtDecode from 'jwt-decode';
 import React, { Component } from 'react';
 import { Redirect } from 'react-router-dom';
-import { ViewTitle } from 'admin-on-rest/lib/mui';
-import Card from 'material-ui/Card/Card';
-import CardActions from 'material-ui/Card/CardActions';
-import CardText from 'material-ui/Card/CardText';
-import CircularProgress from 'material-ui/CircularProgress';
-import FlatButton from 'material-ui/FlatButton';
-import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
-import { teal800 } from 'material-ui/styles/colors';
-import RaisedButton from 'material-ui/RaisedButton';
+import {
+    Avatar,
+    Card,
+    CardActions,
+    CardContent,
+    CircularProgress,
+    Button,
+    Typography
+} from '@material-ui/core';
+import ContextSwitchIcon from '@material-ui/icons/SwapCalls';
 
-import { muiTheme, styles } from '../Theme';
+import { styles } from '../theme';
 import PermissionsStore from '../auth/PermissionsStore';
 import { apiErrorHandler } from '../utils';
 import DomainTreeInput from '../inputs/DomainTreeInput';
@@ -43,7 +44,10 @@ class ContextChanger extends Component {
             const userID = jwtDecode(localStorage.getItem('id_token')).sub;
             PermissionsStore.getAndLoadPermissions({ userID, currentContext: value })
                 .then(result => {
-                    this.setState({ redirect: true });
+                    // Because of rendering happening before the server returns in React Admin,
+                    // a simple unmounting of the Admin component will no longer work to reset
+                    // the permissions. Here we redirect the window now to the portal.
+                    window.location.href = process.env.REACT_APP_PORTAL_URL;
                 })
                 .catch(error => {
                     this.handleAPIError(error);
@@ -64,47 +68,63 @@ class ContextChanger extends Component {
         return redirect ? (
             <Redirect push to="/" />
         ) : (
-            <MuiThemeProvider muiTheme={muiTheme}>
-                <div style={{ ...styles.main, backgroundColor: teal800 }}>
-                    <Card style={styles.cardCentered}>
-                        {changing ? (
-                            <CardText>
-                                <CircularProgress style={{ margin: '7rem' }} />
-                            </CardText>
-                        ) : (
-                            <div>
-                                <ViewTitle title="Context Changer" />
-                                <CardText>Select the Domain or Site.</CardText>
-                                <CardText>
-                                    {treeData ? (
-                                        <DomainTreeInput
-                                            source="context"
-                                            treeData={treeData}
-                                            value={value}
-                                            onChange={this.handleChange}
-                                            onlyDomains={false}
-                                            useReduxFormField={false}
-                                        />
-                                    ) : (
-                                        <CircularProgress />
-                                    )}
-                                </CardText>
-                                <CardActions>
-                                    <FlatButton
-                                        label="Back"
+            <div style={{ ...styles.main }}>
+                <Card style={styles.cardCentered}>
+                    <div style={styles.avatarDiv}>
+                        <Avatar style={{ ...styles.avatar }}>
+                            <ContextSwitchIcon />
+                        </Avatar>
+                    </div>
+                    <Typography variant="title" align="center" paragraph={true}>
+                        Context Changer
+                    </Typography>
+                    {changing ? (
+                        <CardContent>
+                            <CircularProgress style={{ margin: '7rem' }} />
+                        </CardContent>
+                    ) : (
+                        <React.Fragment>
+                            <Typography>Select the Domain or Site.</Typography>
+                            <CardContent>
+                                {treeData ? (
+                                    <DomainTreeInput
+                                        source="context"
+                                        treeData={treeData}
+                                        value={value}
+                                        onChange={this.handleChange}
+                                        onlyDomains={false}
+                                        useReduxFormField={false}
+                                        customStyle={{
+                                            fontSize: 16,
+                                            height: 40,
+                                            width: 256
+                                        }}
+                                    />
+                                ) : (
+                                    <CircularProgress />
+                                )}
+                                <CardActions style={styles.cardCentered}>
+                                    <Button
+                                        variant="contained"
                                         onClick={() => this.handleSelection(true)}
-                                    />
-                                    <RaisedButton
-                                        label="Confirm"
-                                        primary={true}
+                                        fullWidth
+                                    >
+                                        Back
+                                    </Button>
+                                    <Button
+                                        variant="contained"
+                                        color="primary"
                                         onClick={() => this.handleSelection()}
-                                    />
+                                        fullWidth
+                                    >
+                                        Confirm
+                                    </Button>
                                 </CardActions>
-                            </div>
-                        )}
-                    </Card>
-                </div>
-            </MuiThemeProvider>
+                            </CardContent>
+                        </React.Fragment>
+                    )}
+                </Card>
+            </div>
         );
     }
 }

--- a/admin/src/resources/DomainRole.js
+++ b/admin/src/resources/DomainRole.js
@@ -29,6 +29,8 @@ import DomainRoleEditActions from '../customActions/DomainRoleEditActions';
 
 import DomainRoleFilter from '../filters/DomainRoleFilter';
 
+import DomainTreeInput from '../inputs/DomainTreeInput';
+
 const validationCreateDomainRole = values => {
     const errors = {};
     if (!values.domain_id) {
@@ -95,15 +97,7 @@ export const DomainRoleCreate = props => (
     <Create {...props} title="DomainRole Create">
         <SimpleForm validate={validationCreateDomainRole} redirect="show">
             {PermissionsStore.getResourcePermission('domains', 'list') && (
-                <ReferenceInput
-                    label="Domain"
-                    source="domain_id"
-                    reference="domains"
-                    perPage={0}
-                    allowEmpty
-                >
-                    <SelectInput optionText="name" />
-                </ReferenceInput>
+                <DomainTreeInput label="Domain" source="domain_id" />
             )}
             {PermissionsStore.getResourcePermission('roles', 'list') && (
                 <ReferenceInput

--- a/admin/src/resources/InvitationDomainRole.js
+++ b/admin/src/resources/InvitationDomainRole.js
@@ -24,6 +24,8 @@ import EmptyField from '../fields/EmptyField';
 
 import InvitationDomainRoleFilter from '../filters/InvitationDomainRoleFilter';
 
+import DomainTreeInput from '../inputs/DomainTreeInput';
+
 const validationCreateInvitationDomainRole = values => {
     const errors = {};
     if (!values.invitation_id) {
@@ -111,15 +113,7 @@ export const InvitationDomainRoleCreate = props => (
                 </ReferenceInput>
             )}
             {PermissionsStore.getResourcePermission('domains', 'list') && (
-                <ReferenceInput
-                    label="Domain"
-                    source="domain_id"
-                    reference="domains"
-                    perPage={0}
-                    allowEmpty
-                >
-                    <SelectInput optionText="name" />
-                </ReferenceInput>
+                <DomainTreeInput label="Domain" source="domain_id" />
             )}
             {PermissionsStore.getResourcePermission('roles', 'list') && (
                 <ReferenceInput

--- a/admin/src/resources/UserDomainRole.js
+++ b/admin/src/resources/UserDomainRole.js
@@ -24,6 +24,8 @@ import EmptyField from '../fields/EmptyField';
 
 import UserDomainRoleFilter from '../filters/UserDomainRoleFilter';
 
+import DomainTreeInput from '../inputs/DomainTreeInput';
+
 const validationCreateUserDomainRole = values => {
     const errors = {};
     if (!values.user_id) {
@@ -111,15 +113,7 @@ export const UserDomainRoleCreate = props => (
                 </ReferenceInput>
             )}
             {PermissionsStore.getResourcePermission('domains', 'list') && (
-                <ReferenceInput
-                    label="Domain"
-                    source="domain_id"
-                    reference="domains"
-                    perPage={0}
-                    allowEmpty
-                >
-                    <SelectInput optionText="name" />
-                </ReferenceInput>
+                <DomainTreeInput label="Domain" source="domain_id" />
             )}
             {PermissionsStore.getResourcePermission('roles', 'list') && (
                 <ReferenceInput

--- a/admin/src/theme.js
+++ b/admin/src/theme.js
@@ -153,5 +153,11 @@ export const styles = {
         textTransform: 'uppercase',
         fontWeight: 500,
         fontSize: 14
+    },
+    treeSelect: {
+        fontSize: 16,
+        height: 40,
+        width: 256,
+        marginTop: 40
     }
 };

--- a/admin/src/theme.js
+++ b/admin/src/theme.js
@@ -23,7 +23,7 @@ export const styles = {
         height: '1px',
         alignItems: 'center',
         justifyContent: 'center',
-        background: 'url(https://ok6static.oktacdn.com/bc/image/fileStoreRecord?id=fs0b4j8f6xdnwtN4B2p6)',
+        background: teal[500],
         backgroundRepeat: 'no-repeat',
         backgroundSize: 'cover'
     },
@@ -39,7 +39,8 @@ export const styles = {
         margin: '1em',
         textAlign: 'center',
         width: 60,
-        height: 60
+        height: 60,
+        backgroundColor: teal[500]
     },
     avatarDiv: {
         display: 'flex',

--- a/admin/yarn.lock
+++ b/admin/yarn.lock
@@ -2,17 +2,6 @@
 # yarn lockfile v1
 
 
-"@ant-design/icons-react@~1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@ant-design/icons-react/-/icons-react-1.1.1.tgz#6b58eb7cc5612392a2c4347d27d85e599d130661"
-  dependencies:
-    ant-design-palettes "^1.1.3"
-    babel-runtime "^6.26.0"
-
-"@ant-design/icons@~1.1.5":
-  version "1.1.11"
-  resolved "https://registry.yarnpkg.com/@ant-design/icons/-/icons-1.1.11.tgz#24cc05aa77c31aeb09823e150bf3a2443bcdc48b"
-
 "@babel/runtime-corejs2@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/runtime-corejs2/-/runtime-corejs2-7.0.0.tgz#786711ee099c2c2af7875638866c1259eff30a8c"
@@ -240,23 +229,14 @@ ansi-styles@^3.0.0, ansi-styles@^3.2.1:
   dependencies:
     color-convert "^1.9.0"
 
-ant-design-palettes@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/ant-design-palettes/-/ant-design-palettes-1.1.3.tgz#84119b1a4d86363adc52a38d587e65336a0a27dd"
+antd@3.6.4:
+  version "3.6.4"
+  resolved "https://registry.yarnpkg.com/antd/-/antd-3.6.4.tgz#9a664aa2dcf7e027144934373b85395fb30a3373"
   dependencies:
-    tinycolor2 "^1.4.1"
-
-antd@^3.6.4:
-  version "3.9.2"
-  resolved "https://registry.yarnpkg.com/antd/-/antd-3.9.2.tgz#7f1007da4fc746e8a0d9bb6846b70b6001374ed9"
-  dependencies:
-    "@ant-design/icons" "~1.1.5"
-    "@ant-design/icons-react" "~1.1.1"
     array-tree-filter "^2.0.0"
     babel-runtime "6.x"
     classnames "~2.2.0"
     create-react-class "^15.6.0"
-    create-react-context "0.2.2"
     css-animation "^1.2.5"
     dom-closest "^0.2.0"
     enquire.js "^2.1.1"
@@ -267,36 +247,33 @@ antd@^3.6.4:
     prop-types "^15.5.7"
     raf "^3.4.0"
     rc-animate "^2.4.1"
-    rc-calendar "~9.7.3"
-    rc-cascader "~0.16.0"
+    rc-calendar "~9.6.0"
+    rc-cascader "~0.13.0"
     rc-checkbox "~2.1.5"
-    rc-collapse "~1.10.0"
-    rc-dialog "~7.2.0"
-    rc-drawer "~1.7.3"
-    rc-dropdown "~2.2.0"
+    rc-collapse "~1.9.0"
+    rc-dialog "~7.1.0"
+    rc-dropdown "~2.1.0"
     rc-editor-mention "^1.0.2"
     rc-form "^2.1.0"
     rc-input-number "~4.0.0"
-    rc-menu "~7.4.1"
-    rc-notification "~3.2.0"
-    rc-pagination "~1.17.0"
+    rc-menu "~7.0.2"
+    rc-notification "~3.1.1"
+    rc-pagination "~1.16.1"
     rc-progress "~2.2.2"
     rc-rate "~2.4.0"
-    rc-select "~8.2.6"
+    rc-select "~8.0.7"
     rc-slider "~8.6.0"
-    rc-steps "~3.3.0"
-    rc-switch "~1.7.0"
-    rc-table "~6.3.2"
-    rc-tabs "~9.4.0"
-    rc-time-picker "~3.4.0"
+    rc-steps "~3.1.0"
+    rc-switch "~1.6.0"
+    rc-table "~6.1.0"
+    rc-tabs "~9.2.0"
+    rc-time-picker "~3.3.0"
     rc-tooltip "~3.7.0"
-    rc-tree "~1.14.5"
-    rc-tree-select "~2.2.0"
-    rc-trigger "^2.5.4"
-    rc-upload "~2.5.0"
+    rc-tree "~1.8.0"
+    rc-tree-select "~1.12.0"
+    rc-upload "~2.4.0"
     rc-util "^4.0.4"
     react-lazy-load "^3.0.12"
-    react-lifecycles-compat "^3.0.2"
     react-slick "~0.23.1"
     shallowequal "^1.0.1"
     warning "~4.0.1"
@@ -1950,20 +1927,13 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-create-react-class@^15.5.2, create-react-class@^15.5.3, create-react-class@^15.6.0:
+create-react-class@15.x, create-react-class@^15.5.2, create-react-class@^15.5.3, create-react-class@^15.6.0:
   version "15.6.3"
   resolved "https://registry.yarnpkg.com/create-react-class/-/create-react-class-15.6.3.tgz#2d73237fb3f970ae6ebe011a9e66f46dbca80036"
   dependencies:
     fbjs "^0.8.9"
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
-
-create-react-context@0.2.2:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/create-react-context/-/create-react-context-0.2.2.tgz#9836542f9aaa22868cd7d4a6f82667df38019dca"
-  dependencies:
-    fbjs "^0.8.0"
-    gud "^1.0.0"
 
 cross-spawn@5.1.0, cross-spawn@^5.0.1, cross-spawn@^5.1.0:
   version "5.1.0"
@@ -3011,7 +2981,7 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "^2.0.0"
 
-fbjs@^0.8.0, fbjs@^0.8.1, fbjs@^0.8.15, fbjs@^0.8.16, fbjs@^0.8.9:
+fbjs@^0.8.1, fbjs@^0.8.15, fbjs@^0.8.9:
   version "0.8.17"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
   dependencies:
@@ -3392,10 +3362,6 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
 growly@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
-
-gud@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/gud/-/gud-1.0.0.tgz#a489581b17e6a70beca9abe3ae57de7a499852c0"
 
 gzip-size@3.0.0:
   version "3.0.0"
@@ -6072,7 +6038,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@15.x, prop-types@^15.5.0, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.6, prop-types@^15.5.7, prop-types@^15.5.8, prop-types@^15.5.9, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@~15.6.1:
+prop-types@15.x, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.6, prop-types@^15.5.7, prop-types@^15.5.8, prop-types@^15.5.9, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@~15.6.1:
   version "15.6.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
   dependencies:
@@ -6163,7 +6129,7 @@ querystringify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.0.0.tgz#fa3ed6e68eb15159457c89b37bc6472833195755"
 
-ra-core@^2.0.0, ra-core@^2.3.2:
+ra-core@^2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/ra-core/-/ra-core-2.3.2.tgz#9e028e45fd4e7ab01c965c4869ca0fd6e774d6a0"
   dependencies:
@@ -6186,11 +6152,11 @@ ra-core@^2.0.0, ra-core@^2.3.2:
     reselect "~3.0.0"
     warning "~3.0.0"
 
-ra-language-english@^2.0.0, ra-language-english@^2.3.0:
+ra-language-english@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/ra-language-english/-/ra-language-english-2.3.0.tgz#d25247bd148a57b02ff0480a66388220ee72ef16"
 
-ra-ui-materialui@^2.0.0:
+ra-ui-materialui@^2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/ra-ui-materialui/-/ra-ui-materialui-2.3.2.tgz#b690654b89f28d5f664d7dd547f65496b2676ba5"
   dependencies:
@@ -6258,7 +6224,7 @@ raw-body@2.3.2:
     iconv-lite "0.4.19"
     unpipe "1.0.0"
 
-rc-align@^2.4.0, rc-align@^2.4.1:
+rc-align@^2.4.0:
   version "2.4.3"
   resolved "https://registry.yarnpkg.com/rc-align/-/rc-align-2.4.3.tgz#b9b3c2a6d68adae71a8e1d041cd5e3b2a655f99a"
   dependencies:
@@ -6278,22 +6244,20 @@ rc-animate@2.x, rc-animate@^2.3.0, rc-animate@^2.4.1:
     raf "^3.4.0"
     react-lifecycles-compat "^3.0.4"
 
-rc-animate@^3.0.0-rc.1, rc-animate@^3.0.0-rc.4, rc-animate@^3.0.0-rc.5:
-  version "3.0.0-rc.6"
-  resolved "https://registry.yarnpkg.com/rc-animate/-/rc-animate-3.0.0-rc.6.tgz#04288eefa118e0cae214536c8a903ffaac1bc3fb"
+rc-animate@^2.0.2:
+  version "2.5.4"
+  resolved "https://registry.yarnpkg.com/rc-animate/-/rc-animate-2.5.4.tgz#3b308c42e137a2e3fb578650fdb145c2100fcc35"
   dependencies:
     babel-runtime "6.x"
-    classnames "^2.2.5"
-    component-classes "^1.2.6"
-    fbjs "^0.8.16"
+    classnames "^2.2.6"
+    css-animation "^1.3.2"
     prop-types "15.x"
     raf "^3.4.0"
-    rc-util "^4.5.0"
     react-lifecycles-compat "^3.0.4"
 
-rc-calendar@~9.7.3:
-  version "9.7.8"
-  resolved "https://registry.yarnpkg.com/rc-calendar/-/rc-calendar-9.7.8.tgz#f3e0f19b483db29b93fc5ebb65009d1e19c7b799"
+rc-calendar@~9.6.0:
+  version "9.6.2"
+  resolved "https://registry.yarnpkg.com/rc-calendar/-/rc-calendar-9.6.2.tgz#c7309db41225f4b8c81d5a1dcbe46d8ce07b6aee"
   dependencies:
     babel-runtime "6.x"
     classnames "2.x"
@@ -6303,16 +6267,15 @@ rc-calendar@~9.7.3:
     rc-trigger "^2.2.0"
     rc-util "^4.1.1"
 
-rc-cascader@~0.16.0:
-  version "0.16.0"
-  resolved "https://registry.yarnpkg.com/rc-cascader/-/rc-cascader-0.16.0.tgz#11baa854c2aaa2d6a8f601dec75dd136d59c5156"
+rc-cascader@~0.13.0:
+  version "0.13.1"
+  resolved "https://registry.yarnpkg.com/rc-cascader/-/rc-cascader-0.13.1.tgz#157df251c5da734bf134b7a595a9b06446a6db80"
   dependencies:
     array-tree-filter "^1.0.0"
     prop-types "^15.5.8"
     rc-trigger "^2.2.0"
     rc-util "^4.0.4"
     shallow-equal "^1.0.0"
-    warning "^4.0.1"
 
 rc-checkbox@~2.1.5:
   version "2.1.5"
@@ -6323,39 +6286,30 @@ rc-checkbox@~2.1.5:
     prop-types "15.x"
     rc-util "^4.0.4"
 
-rc-collapse@~1.10.0:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/rc-collapse/-/rc-collapse-1.10.0.tgz#b39578633a1e033391597776758763a10d3bc261"
+rc-collapse@~1.9.0:
+  version "1.9.3"
+  resolved "https://registry.yarnpkg.com/rc-collapse/-/rc-collapse-1.9.3.tgz#d9741db06a823353e1fd1aec3ba4c0f9d8af4b26"
   dependencies:
     classnames "2.x"
     css-animation "1.x"
     prop-types "^15.5.6"
     rc-animate "2.x"
 
-rc-dialog@~7.2.0:
-  version "7.2.1"
-  resolved "https://registry.yarnpkg.com/rc-dialog/-/rc-dialog-7.2.1.tgz#ac92fcffdf2a0eaa64b77f829336653d911a57be"
+rc-dialog@~7.1.0:
+  version "7.1.8"
+  resolved "https://registry.yarnpkg.com/rc-dialog/-/rc-dialog-7.1.8.tgz#5402748a256de2e19ad590f743950c823c6df6b5"
   dependencies:
     babel-runtime "6.x"
     rc-animate "2.x"
     rc-util "^4.4.0"
 
-rc-drawer@~1.7.3:
-  version "1.7.6"
-  resolved "https://registry.yarnpkg.com/rc-drawer/-/rc-drawer-1.7.6.tgz#925ce0768cf81ef5fa83eb22d90c603422b1b1b1"
-  dependencies:
-    babel-runtime "6.x"
-    classnames "^2.2.5"
-    prop-types "^15.5.0"
-    rc-util "^4.5.1"
-
-rc-dropdown@~2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/rc-dropdown/-/rc-dropdown-2.2.0.tgz#a905067666ce73c0ce26cf0980e7b75b46126825"
+rc-dropdown@~2.1.0:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/rc-dropdown/-/rc-dropdown-2.1.2.tgz#f99844d2ec17707232f244dda75c8d8a623d0272"
   dependencies:
     babel-runtime "^6.26.0"
     prop-types "^15.5.8"
-    rc-trigger "^2.5.1"
+    rc-trigger "^2.2.2"
     react-lifecycles-compat "^3.0.2"
 
 rc-editor-core@~0.8.3:
@@ -6413,9 +6367,9 @@ rc-input-number@~4.0.0:
     rc-util "^4.5.1"
     rmc-feedback "^2.0.0"
 
-rc-menu@^7.3.0, rc-menu@~7.4.1:
-  version "7.4.8"
-  resolved "https://registry.yarnpkg.com/rc-menu/-/rc-menu-7.4.8.tgz#c9b39bc0909a7d998c4b179470c8a0c2e94cd7c3"
+rc-menu@^7.0.2:
+  version "7.4.9"
+  resolved "https://registry.yarnpkg.com/rc-menu/-/rc-menu-7.4.9.tgz#9fdddde8ddb7bc6104b08bd0b255c91e7655a717"
   dependencies:
     babel-runtime "6.x"
     classnames "2.x"
@@ -6428,9 +6382,22 @@ rc-menu@^7.3.0, rc-menu@~7.4.1:
     rc-util "^4.1.0"
     resize-observer-polyfill "^1.5.0"
 
-rc-notification@~3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/rc-notification/-/rc-notification-3.2.0.tgz#bbfb6a92c4e54c9eeb7ac51a7e8c64011ea12ab1"
+rc-menu@~7.0.2:
+  version "7.0.5"
+  resolved "https://registry.yarnpkg.com/rc-menu/-/rc-menu-7.0.5.tgz#986b65df5ad227aadf399ea374b98d2313802316"
+  dependencies:
+    babel-runtime "6.x"
+    classnames "2.x"
+    dom-scroll-into-view "1.x"
+    mini-store "^1.1.0"
+    prop-types "^15.5.6"
+    rc-animate "2.x"
+    rc-trigger "^2.3.0"
+    rc-util "^4.1.0"
+
+rc-notification@~3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/rc-notification/-/rc-notification-3.1.1.tgz#14eac6730db1d59adaf569dad9fe82a2f33cd23a"
   dependencies:
     babel-runtime "6.x"
     classnames "2.x"
@@ -6438,9 +6405,9 @@ rc-notification@~3.2.0:
     rc-animate "2.x"
     rc-util "^4.0.4"
 
-rc-pagination@~1.17.0:
-  version "1.17.2"
-  resolved "https://registry.yarnpkg.com/rc-pagination/-/rc-pagination-1.17.2.tgz#2ee82d2fea4f25177dda0f66dc6c819037fd93ad"
+rc-pagination@~1.16.1:
+  version "1.16.5"
+  resolved "https://registry.yarnpkg.com/rc-pagination/-/rc-pagination-1.16.5.tgz#550a758035e1957ccfa2f71ee6e55657da729679"
   dependencies:
     babel-runtime "6.x"
     prop-types "^15.5.7"
@@ -6461,22 +6428,21 @@ rc-rate@~2.4.0:
     prop-types "^15.5.8"
     rc-util "^4.3.0"
 
-rc-select@~8.2.6:
-  version "8.2.8"
-  resolved "https://registry.yarnpkg.com/rc-select/-/rc-select-8.2.8.tgz#3cfbce3d3128d47f2af0b74150dc54870828e3ee"
+rc-select@~8.0.7:
+  version "8.0.14"
+  resolved "https://registry.yarnpkg.com/rc-select/-/rc-select-8.0.14.tgz#ff1763458a15519bea010ea15fecf6f59095b346"
   dependencies:
     babel-runtime "^6.23.0"
     classnames "2.x"
     component-classes "1.x"
     dom-scroll-into-view "1.x"
     prop-types "^15.5.8"
-    raf "^3.4.0"
     rc-animate "2.x"
-    rc-menu "^7.3.0"
-    rc-trigger "^2.5.4"
+    rc-menu "^7.0.2"
+    rc-trigger "^2.2.0"
     rc-util "^4.0.4"
     react-lifecycles-compat "^3.0.2"
-    warning "^4.0.2"
+    warning "^3.0.0"
 
 rc-slider@~8.6.0:
   version "8.6.3"
@@ -6490,29 +6456,28 @@ rc-slider@~8.6.0:
     shallowequal "^1.0.1"
     warning "^3.0.0"
 
-rc-steps@~3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/rc-steps/-/rc-steps-3.3.0.tgz#8817c438a6a5648997c7edb51bde727e6f32e132"
+rc-steps@~3.1.0:
+  version "3.1.1"
+  resolved "http://registry.npmjs.org/rc-steps/-/rc-steps-3.1.1.tgz#79583ad808309d82b8e011676321d153fd7ca403"
   dependencies:
     babel-runtime "^6.23.0"
     classnames "^2.2.3"
     lodash "^4.17.5"
     prop-types "^15.5.7"
 
-rc-switch@~1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/rc-switch/-/rc-switch-1.7.0.tgz#a655f08951d6db94d83f162da5b69506cb703b6f"
+rc-switch@~1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/rc-switch/-/rc-switch-1.6.0.tgz#c2d7369bdb87c1fd45e84989a27c1fb2f201d2fd"
   dependencies:
     babel-runtime "^6.23.0"
     classnames "^2.2.1"
     prop-types "^15.5.6"
 
-rc-table@~6.3.2:
-  version "6.3.4"
-  resolved "https://registry.yarnpkg.com/rc-table/-/rc-table-6.3.4.tgz#5ec6e37f18661228161bcaa7bbf8cbaf132405ec"
+rc-table@~6.1.0:
+  version "6.1.15"
+  resolved "https://registry.yarnpkg.com/rc-table/-/rc-table-6.1.15.tgz#c2da37118626604de70742ae87bffafe17351189"
   dependencies:
     babel-runtime "6.x"
-    classnames "^2.2.5"
     component-classes "^1.2.6"
     lodash "^4.17.5"
     mini-store "^1.0.2"
@@ -6522,21 +6487,22 @@ rc-table@~6.3.2:
     shallowequal "^1.0.2"
     warning "^3.0.0"
 
-rc-tabs@~9.4.0:
-  version "9.4.3"
-  resolved "https://registry.yarnpkg.com/rc-tabs/-/rc-tabs-9.4.3.tgz#9bbc87b41eb8de8909a9cbf3e11066c76ce56fe8"
+rc-tabs@~9.2.0:
+  version "9.2.6"
+  resolved "https://registry.yarnpkg.com/rc-tabs/-/rc-tabs-9.2.6.tgz#4bd88086496b4f2d19c75c832fe7ec08e6b1643d"
   dependencies:
     babel-runtime "6.x"
     classnames "2.x"
+    create-react-class "15.x"
     lodash "^4.17.5"
     prop-types "15.x"
     rc-hammerjs "~0.6.0"
     rc-util "^4.0.4"
     warning "^3.0.0"
 
-rc-time-picker@~3.4.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/rc-time-picker/-/rc-time-picker-3.4.0.tgz#274e80122f885b37a4eace7393f3a25334fa141f"
+rc-time-picker@~3.3.0:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/rc-time-picker/-/rc-time-picker-3.3.1.tgz#94f8bbd51e6b93de1f01e78064aef1e6d765b367"
   dependencies:
     babel-runtime "6.x"
     classnames "2.x"
@@ -6552,35 +6518,41 @@ rc-tooltip@^3.7.0, rc-tooltip@~3.7.0:
     prop-types "^15.5.8"
     rc-trigger "^2.2.2"
 
-rc-tree-select@~2.2.0:
-  version "2.2.5"
-  resolved "https://registry.yarnpkg.com/rc-tree-select/-/rc-tree-select-2.2.5.tgz#79a078413e1f686a0b6cc638b2faadc47a45c257"
+rc-tree-select@~1.12.0:
+  version "1.12.13"
+  resolved "https://registry.yarnpkg.com/rc-tree-select/-/rc-tree-select-1.12.13.tgz#3bf5684a3e38fbfbf8cc149d4f4a5d62f5ef0d47"
   dependencies:
     babel-runtime "^6.23.0"
     classnames "^2.2.1"
     prop-types "^15.5.8"
-    raf "^3.4.0"
-    rc-animate "^3.0.0-rc.4"
-    rc-tree "~1.14.3"
-    rc-trigger "^3.0.0-rc.2"
+    rc-animate "^2.0.2"
+    rc-tree "~1.7.1"
+    rc-trigger "^2.2.2"
     rc-util "^4.5.0"
-    react-lifecycles-compat "^3.0.4"
-    shallowequal "^1.0.2"
-    warning "^4.0.1"
 
-rc-tree@~1.14.3, rc-tree@~1.14.5:
-  version "1.14.6"
-  resolved "https://registry.yarnpkg.com/rc-tree/-/rc-tree-1.14.6.tgz#5ee5b25d55fcc93f29ea72c4e9aedd9ef2b70fa2"
+rc-tree@~1.7.1:
+  version "1.7.11"
+  resolved "http://registry.npmjs.org/rc-tree/-/rc-tree-1.7.11.tgz#349de6383fc7d22bf4c13b0751794111022adddf"
   dependencies:
     babel-runtime "^6.23.0"
     classnames "2.x"
     prop-types "^15.5.8"
-    rc-animate "^3.0.0-rc.5"
-    rc-util "^4.5.1"
-    react-lifecycles-compat "^3.0.4"
+    rc-animate "2.x"
+    rc-util "^4.0.4"
     warning "^3.0.0"
 
-rc-trigger@^2.2.0, rc-trigger@^2.2.2, rc-trigger@^2.3.0, rc-trigger@^2.5.1, rc-trigger@^2.5.4:
+rc-tree@~1.8.0:
+  version "1.8.3"
+  resolved "https://registry.yarnpkg.com/rc-tree/-/rc-tree-1.8.3.tgz#2875e83bc951b5ed7577c1038490f8245d79a37f"
+  dependencies:
+    babel-runtime "^6.23.0"
+    classnames "2.x"
+    prop-types "^15.5.8"
+    rc-animate "2.x"
+    rc-util "^4.0.4"
+    warning "^3.0.0"
+
+rc-trigger@^2.2.0, rc-trigger@^2.2.2, rc-trigger@^2.3.0:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/rc-trigger/-/rc-trigger-2.6.1.tgz#8a312c92440b58f26b5d4f8126e421d890e01532"
   dependencies:
@@ -6591,21 +6563,9 @@ rc-trigger@^2.2.0, rc-trigger@^2.2.2, rc-trigger@^2.3.0, rc-trigger@^2.5.1, rc-t
     rc-animate "2.x"
     rc-util "^4.4.0"
 
-rc-trigger@^3.0.0-rc.2:
-  version "3.0.0-rc.3"
-  resolved "https://registry.yarnpkg.com/rc-trigger/-/rc-trigger-3.0.0-rc.3.tgz#35842df1674d25315e1426a44882a4c97652258b"
-  dependencies:
-    babel-runtime "6.x"
-    classnames "^2.2.6"
-    prop-types "15.x"
-    raf "^3.4.0"
-    rc-align "^2.4.1"
-    rc-animate "^3.0.0-rc.1"
-    rc-util "^4.4.0"
-
-rc-upload@~2.5.0:
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/rc-upload/-/rc-upload-2.5.1.tgz#7ae0c9038d98ba8750e9466d8f969e1b4bc9f0e0"
+rc-upload@~2.4.0:
+  version "2.4.4"
+  resolved "https://registry.yarnpkg.com/rc-upload/-/rc-upload-2.4.4.tgz#28e1e6a3e44d1b1f92e57e21927cfa2763ac2a21"
   dependencies:
     babel-runtime "6.x"
     classnames "^2.2.5"
@@ -6630,13 +6590,13 @@ rc@^1.0.1, rc@^1.1.6, rc@^1.1.7, rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-admin@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/react-admin/-/react-admin-2.0.0.tgz#ea834365d21094b91ee1c60fc116fbd2d0f21e85"
+react-admin@^2.0.0:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/react-admin/-/react-admin-2.3.2.tgz#4fa8384f80cb2cc1c8ab0759721cbe2fcebcde3e"
   dependencies:
-    ra-core "^2.0.0"
-    ra-language-english "^2.0.0"
-    ra-ui-materialui "^2.0.0"
+    ra-core "^2.3.2"
+    ra-language-english "^2.3.0"
+    ra-ui-materialui "^2.3.2"
 
 react-autosuggest@^9.3.2:
   version "9.4.2"
@@ -8009,10 +7969,6 @@ tiny-invariant@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.0.0.tgz#03f96fef4d3ba911f97ed467e1b88bca3d4d9d9f"
 
-tinycolor2@^1.4.1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/tinycolor2/-/tinycolor2-1.4.1.tgz#f4fad333447bc0b07d4dc8e9209d8f39a8ac77e8"
-
 tmp@^0.0.33:
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
@@ -8347,7 +8303,7 @@ warning@^3.0.0, warning@~3.0.0:
   dependencies:
     loose-envify "^1.0.0"
 
-warning@^4.0.1, warning@^4.0.2, warning@~4.0.1:
+warning@^4.0.1, warning@~4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/warning/-/warning-4.0.2.tgz#aa6876480872116fa3e11d434b0d0d8d91e44607"
   dependencies:


### PR DESCRIPTION
**Background:** The basic admin view and resources have been upgraded (via generation) to React Admin (previously Admin on Rest). The context changer was no longer working.

**What was done:** The context changer component was upgraded to use the new material-ui v1 components and the look of the context changer was changed to suit the new look of the admin. 
The context changer component uses the `DomainTreeInput/TreeviewSelect` components for the selector. A `customStyle` prop was added for the ability to override the default style of the component.

ALSO PS. Added `DomainTreeInput` back to where it was used in old AOR, and fixed the error on creation of a composite key object.

![screenshot from 2018-09-25 12-09-54](https://user-images.githubusercontent.com/20847795/46008069-f6fd1a80-c0bb-11e8-9e51-b7fbfcc7d844.png)

 